### PR TITLE
#79: Create a User Profile macro

### DIFF
--- a/xwiki-pro-macros-api/pom.xml
+++ b/xwiki-pro-macros-api/pom.xml
@@ -49,5 +49,16 @@
       <groupId>org.webjars</groupId>
       <artifactId>jquery</artifactId>
     </dependency>
+    <!-- Dependencies needed by the User List macro -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-template-api</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-displayer</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-pro-macros-api/pom.xml
+++ b/xwiki-pro-macros-api/pom.xml
@@ -49,16 +49,26 @@
       <groupId>org.webjars</groupId>
       <artifactId>jquery</artifactId>
     </dependency>
-    <!-- Dependencies needed by the User List macro -->
-    <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-template-api</artifactId>
-      <version>${platform.version}</version>
-    </dependency>
+    <!-- Dependencies needed by the User Profile macro -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-displayer</artifactId>
       <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-api</artifactId>
+      <version>${rendering.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-transformation-macro</artifactId>
+      <version>${rendering.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model</artifactId>
+      <version>${platform.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
@@ -1,0 +1,94 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.userprofile.internal.macro;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.displayer.HTMLDisplayerException;
+import org.xwiki.displayer.HTMLDisplayerManager;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.RawBlock;
+import org.xwiki.rendering.macro.AbstractMacro;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.text.StringUtils;
+
+import com.xwiki.macros.userprofile.macro.UserProfileMacroParameters;
+import com.xwiki.macros.userprofile.macro.UserReference;
+
+/**
+ * This macro displays a user profile.
+ *
+ * @version $Id$
+ */
+@Component
+@Named("userProfile")
+@Singleton
+public class UserProfileMacro extends AbstractMacro<UserProfileMacroParameters>
+{
+    @Inject
+    private HTMLDisplayerManager htmlDisplayerManager;
+
+    @Inject
+    @Named("default")
+    private EntityReferenceSerializer<String> referenceSerializer;
+
+    /**
+     * Create and initialize the descriptor of the macro.
+     */
+    public UserProfileMacro()
+    {
+        super("User profile", "Displays a user profile with custom set of properties",
+            UserProfileMacroParameters.class);
+    }
+
+    @Override
+    public List<Block> execute(UserProfileMacroParameters parameters, String content,
+        MacroTransformationContext context) throws MacroExecutionException
+    {
+
+        Map<String, String> params = new HashMap<>();
+        try {
+            String userReference = referenceSerializer.serialize(parameters.getUser());
+            params.put("user", userReference);
+            params.put("properties", StringUtils.join(parameters.getProperties(), ','));
+            String html = htmlDisplayerManager.display(UserReference.class, content, params, "view");
+            return Arrays.asList(new RawBlock(html, Syntax.HTML_5_0));
+        } catch (HTMLDisplayerException e) {
+            throw new MacroExecutionException("Failed to render the userProfile viewer template.", e);
+        }
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return false;
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
@@ -76,8 +76,8 @@ public class UserProfileMacro extends AbstractMacro<UserProfileMacroParameters>
 
         Map<String, String> params = new HashMap<>();
         try {
-            String userReference = referenceSerializer.serialize(parameters.getUser());
-            params.put("user", userReference);
+            String userReference = referenceSerializer.serialize(parameters.getReference());
+            params.put("reference", userReference);
             params.put("properties", StringUtils.join(parameters.getProperties(), ','));
             String html = htmlDisplayerManager.display(UserReference.class, content, params, "view");
             return Arrays.asList(new RawBlock(html, Syntax.HTML_5_0));

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserProfileMacro.java
@@ -31,7 +31,6 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.displayer.HTMLDisplayerException;
 import org.xwiki.displayer.HTMLDisplayerManager;
-import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.RawBlock;
 import org.xwiki.rendering.macro.AbstractMacro;
@@ -56,10 +55,6 @@ public class UserProfileMacro extends AbstractMacro<UserProfileMacroParameters>
     @Inject
     private HTMLDisplayerManager htmlDisplayerManager;
 
-    @Inject
-    @Named("default")
-    private EntityReferenceSerializer<String> referenceSerializer;
-
     /**
      * Create and initialize the descriptor of the macro.
      */
@@ -73,13 +68,10 @@ public class UserProfileMacro extends AbstractMacro<UserProfileMacroParameters>
     public List<Block> execute(UserProfileMacroParameters parameters, String content,
         MacroTransformationContext context) throws MacroExecutionException
     {
-
         Map<String, String> params = new HashMap<>();
         try {
-            String userReference = referenceSerializer.serialize(parameters.getReference());
-            params.put("reference", userReference);
             params.put("properties", StringUtils.join(parameters.getProperties(), ','));
-            String html = htmlDisplayerManager.display(UserReference.class, content, params, "view");
+            String html = htmlDisplayerManager.display(UserReference.class, parameters.getReference(), params, "view");
             return Arrays.asList(new RawBlock(html, Syntax.HTML_5_0));
         } catch (HTMLDisplayerException e) {
             throw new MacroExecutionException("Failed to render the userProfile viewer template.", e);

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserReferenceConverter.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/internal/macro/UserReferenceConverter.java
@@ -1,0 +1,66 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.userprofile.internal.macro;
+
+import java.lang.reflect.Type;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.properties.converter.AbstractConverter;
+import org.xwiki.properties.converter.ConversionException;
+import org.xwiki.text.StringUtils;
+
+import com.xwiki.macros.userprofile.macro.UserReference;
+
+/**
+ * XWiki Properties Bean Converter to convert Strings into {@link com.xwiki.macros.userprofile.macro.UserReference}.
+ *
+ * @version $Id$
+ * @see org.xwiki.properties.converter.Converter
+ */
+@Component
+@Singleton
+public class UserReferenceConverter extends AbstractConverter<UserReference>
+{
+    @Inject
+    private DocumentReferenceResolver<String> referenceResolver;
+
+    @Override
+    protected <G extends UserReference> G convertToType(Type targetType, Object value)
+    {
+        if (value != null) {
+            String valueString = value.toString().trim();
+            if (!StringUtils.isEmpty(valueString)) {
+                return (G) new UserReference(referenceResolver.resolve(valueString));
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    protected String convertToString(UserReference value)
+    {
+        throw new ConversionException("not implemented yet");
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
@@ -19,6 +19,7 @@
  */
 package com.xwiki.macros.userprofile.macro;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.xwiki.properties.annotation.PropertyDescription;
@@ -26,7 +27,7 @@ import org.xwiki.properties.annotation.PropertyName;
 
 public class UserProfileMacroParameters
 {
-    private List<String> properties;
+    private List<String> properties = Arrays.asList("company", "email", "phone", "address");
 
     private UserReference user;
 

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
@@ -19,7 +19,6 @@
  */
 package com.xwiki.macros.userprofile.macro;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.xwiki.properties.annotation.PropertyDescription;
@@ -27,14 +26,14 @@ import org.xwiki.properties.annotation.PropertyName;
 
 public class UserProfileMacroParameters
 {
-    private List<String> properties = Arrays.asList("avatar", "username");
+    private List<String> properties;
 
     private UserReference user;
 
     /**
      * @return a user
      */
-    public UserReference getUser()
+    public UserReference getReference()
     {
         return this.user;
     }
@@ -44,9 +43,9 @@ public class UserProfileMacroParameters
      *
      * @param user list of user references
      */
-    @PropertyName("User")
-    @PropertyDescription("User")
-    public void setUser(UserReference user)
+    @PropertyName("Reference")
+    @PropertyDescription("User reference")
+    public void setReference(UserReference user)
     {
         this.user = user;
     }

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserProfileMacroParameters.java
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.userprofile.macro;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyName;
+
+public class UserProfileMacroParameters
+{
+    private List<String> properties = Arrays.asList("avatar", "username");
+
+    private UserReference user;
+
+    /**
+     * @return a user
+     */
+    public UserReference getUser()
+    {
+        return this.user;
+    }
+
+    /**
+     * Sets a user.
+     *
+     * @param user list of user references
+     */
+    @PropertyName("User")
+    @PropertyDescription("User")
+    public void setUser(UserReference user)
+    {
+        this.user = user;
+    }
+
+    /**
+     * @return list of properties to be displayed
+     */
+    public List<String> getProperties()
+    {
+        return this.properties;
+    }
+
+    /**
+     * Sets a list of property names.
+     *
+     * @param properties list of user properties
+     */
+    @PropertyName("Properties")
+    @PropertyDescription("List of user properties to be displayed")
+    public void setProperties(List<String> properties)
+    {
+        this.properties = properties;
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserReference.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userprofile/macro/UserReference.java
@@ -1,0 +1,40 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.userprofile.macro;
+
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+
+/**
+ * Class used to associate a picker to the UserProfileMacro user parameter.
+ *
+ * @version $Id$
+ */
+public class UserReference extends DocumentReference
+{
+    /**
+     * Default constructor.
+     * @param reference an EntityReference
+     */
+    public UserReference(EntityReference reference)
+    {
+        super(reference);
+    }
+}

--- a/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
@@ -1,0 +1,2 @@
+com.xwiki.macros.userprofile.internal.macro.UserProfileMacro
+com.xwiki.macros.userprofile.internal.macro.UserReferenceConverter

--- a/xwiki-pro-macros-api/src/main/resources/css/userprofile.css
+++ b/xwiki-pro-macros-api/src/main/resources/css/userprofile.css
@@ -1,0 +1,37 @@
+.xwiki-user-profile-box {
+  margin-bottom: 1em;
+  border: 1px solid #e8e8e8;
+  border-radius: 4px;
+}
+
+.xwiki-user-profile-box .xwiki-user-profile-header {
+  padding: 1em;
+  background: #eaeaea;
+}
+
+.xwiki-user-profile-box .xwiki-user-profile-header h2 {
+  font-size: 16px;
+}
+
+.xwiki-user-profile-box .xwiki-user-profile-header .media-left img {
+  max-width: 50px;
+  max-height: 50px;
+}
+
+.xwiki-user-profile-box .xwiki-user-profile-header .xwiki-user-profile-comment {
+  font-style: italic;
+  color: #4d5860;
+}
+
+.xwiki-user-profile-body {
+  padding: 1em;
+}
+
+.xwiki-user-profile-body ul {
+  padding: 0;
+  list-style: none;
+}
+
+.xwiki-user-profile-body li .xwiki-user-profile-attribute-icon {
+  padding-right: 0.2em;
+}

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/edit.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/edit.vm
@@ -1,0 +1,25 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#set ($userPickerParams = {
+  'id': 'user',
+  'name': 'user',
+  'value': $displayer.value
+})
+#userPicker(true $userPickerParams)

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
@@ -21,30 +21,30 @@
 #macro (stripHTML $displayOutput)
   $stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="false" wiki="false"}}'), '{{/html}}')
 #end
-#set ($ref = $displayer.parameters.reference)
-#set ($reference = $services.model.resolveDocument($ref))
-#if ("$!ref" != '' && $xwiki.exists($reference) && $services.security.authorization.hasAccess('view', $reference))
+#set ($userReference = $displayer.value)
+#if ("$!userReference" != '' && $xwiki.exists($userReference) && $services.security.authorization.hasAccess('view', $userReference))
+  #set ($userId = $services.model.serialize($userReference))
   #set ($discard = $xwiki.ssrx.use('css/userprofile.css'))
   #set ($properties = $displayer.parameters.properties.split(','))
-  #set ($userPage = $xwiki.getDocument($reference))
+  #set ($userPage = $xwiki.getDocument($userReference))
   #set ($userObj = $userPage.getObject('XWiki.XWikiUsers'))
   <div class="xwiki-user-profile-box">
     <div class="xwiki-user-profile-header">
       <div class="media">
         <div class="media-left">
-          <a href="$xwiki.getURL($reference)" title="$xwiki.getUserName($reference, false)">
-            #mediumUserAvatar($ref)
+          <a href="$xwiki.getURL($userReference)" title="$escapetool.xml($xwiki.getUserName($userId, false))">
+            #mediumUserAvatar($userId)
           </a>
         </div>
         <div class="media-body">
-          <h2 class="media-heading">$xwiki.getUserName($reference)</h2>
+          <h2 class="media-heading">$xwiki.getUserName($userId)</h2>
           <div class="xwiki-user-profile-comment">
             #stripHTML($userPage.display('comment', 'view'))
           </div>
         </div>
       </div>
     </div>
-    #if ($!displayer.parameters.properties != '')
+    #if ("$!displayer.parameters.properties" != '')
       <div class="xwiki-user-profile-body">
         <ul>
           #foreach ($property in $properties)
@@ -73,6 +73,6 @@
   </div>
 #else
   <div class="box warningmessage">
-    $services.localization.render('rendering.macro.userProfile.parameter.reference.isInvalid')
+    $escapetool.xml($services.localization.render('rendering.macro.userProfile.parameter.reference.isInvalid'))
   </div>
 #end

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
@@ -1,0 +1,74 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## Hack copied from https://github.com/xwiki-contrib/application-changerequest/blob/application-changerequest-1.0.1/application-changerequest-ui/src/main/resources/ChangeRequest/Code/SaveChangeRequestModal.xml#L42
+#macro (stripHTML $displayOutput)
+  $stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="false" wiki="false"}}'), '{{/html}}')
+#end
+#set ($ref = $displayer.parameters.user)
+#if ("$!ref" != '')
+  #set ($discard = $xwiki.ssrx.use('css/userprofile.css'))
+  #set ($reference = $services.model.resolveDocument($ref))
+  #if ($xwiki.exists($reference) && $services.security.authorization.hasAccess('view', $reference))
+    #set ($properties = $displayer.parameters.properties.split(','))
+    #set ($userPage = $xwiki.getDocument($reference))
+    #set ($userObj = $userPage.getObject('XWiki.XWikiUsers'))
+    <div class="xwiki-user-profile-box">
+      <div class="xwiki-user-profile-header">
+        <div class="media">
+          <div class="media-left">
+            <a href="$xwiki.getURL($reference)" title="$xwiki.getUserName($reference, false)">
+              #mediumUserAvatar($ref)
+            </a>
+          </div>
+          <div class="media-body">
+            <h2 class="media-heading">$xwiki.getUserName($reference)</h2>
+            <div class="xwiki-user-profile-comment">
+              #stripHTML($userPage.display('comment', 'view'))
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="xwiki-user-profile-body">
+        <ul>
+          #foreach ($property in $properties)
+            #if ($property == 'email')
+              #set ($icon = 'envelope')
+            #elseif ($property == 'phone')
+              #set ($icon = 'phone')
+            #elseif ($property == 'company')
+              #set ($icon = 'building')
+            #else
+              #set ($icon = $NULL)
+            #end
+            #set ($propertyValue = $userObj.getValue($property))
+            #if ("$!propertyValue" != '')
+              <li>
+                #if ($icon != $NULL)
+                  <span class="xwiki-user-profile-attribute-icon">$services.icon.renderHTML($icon)</span>
+                #end
+                #stripHTML($userPage.display($property, 'view'))
+              </li>
+            #end
+          #end
+        </ul>
+      </div>
+    </div>
+  #end
+#end

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
@@ -21,54 +21,56 @@
 #macro (stripHTML $displayOutput)
   $stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="false" wiki="false"}}'), '{{/html}}')
 #end
-#set ($ref = $displayer.parameters.user)
-#if ("$!ref" != '')
+#set ($ref = $displayer.parameters.reference)
+#set ($reference = $services.model.resolveDocument($ref))
+#if ("$!ref" != '' && $xwiki.exists($reference) && $services.security.authorization.hasAccess('view', $reference))
   #set ($discard = $xwiki.ssrx.use('css/userprofile.css'))
-  #set ($reference = $services.model.resolveDocument($ref))
-  #if ($xwiki.exists($reference) && $services.security.authorization.hasAccess('view', $reference))
-    #set ($properties = $displayer.parameters.properties.split(','))
-    #set ($userPage = $xwiki.getDocument($reference))
-    #set ($userObj = $userPage.getObject('XWiki.XWikiUsers'))
-    <div class="xwiki-user-profile-box">
-      <div class="xwiki-user-profile-header">
-        <div class="media">
-          <div class="media-left">
-            <a href="$xwiki.getURL($reference)" title="$xwiki.getUserName($reference, false)">
-              #mediumUserAvatar($ref)
-            </a>
-          </div>
-          <div class="media-body">
-            <h2 class="media-heading">$xwiki.getUserName($reference)</h2>
-            <div class="xwiki-user-profile-comment">
-              #stripHTML($userPage.display('comment', 'view'))
-            </div>
+  #set ($properties = $displayer.parameters.properties.split(','))
+  #set ($userPage = $xwiki.getDocument($reference))
+  #set ($userObj = $userPage.getObject('XWiki.XWikiUsers'))
+  <div class="xwiki-user-profile-box">
+    <div class="xwiki-user-profile-header">
+      <div class="media">
+        <div class="media-left">
+          <a href="$xwiki.getURL($reference)" title="$xwiki.getUserName($reference, false)">
+            #mediumUserAvatar($ref)
+          </a>
+        </div>
+        <div class="media-body">
+          <h2 class="media-heading">$xwiki.getUserName($reference)</h2>
+          <div class="xwiki-user-profile-comment">
+            #stripHTML($userPage.display('comment', 'view'))
           </div>
         </div>
       </div>
-      <div class="xwiki-user-profile-body">
-        <ul>
-          #foreach ($property in $properties)
-            #if ($property == 'email')
-              #set ($icon = 'envelope')
-            #elseif ($property == 'phone')
-              #set ($icon = 'phone')
-            #elseif ($property == 'company')
-              #set ($icon = 'building')
-            #else
-              #set ($icon = $NULL)
-            #end
-            #set ($propertyValue = $userObj.getValue($property))
-            #if ("$!propertyValue" != '')
-              <li>
-                #if ($icon != $NULL)
-                  <span class="xwiki-user-profile-attribute-icon">$services.icon.renderHTML($icon)</span>
-                #end
-                #stripHTML($userPage.display($property, 'view'))
-              </li>
-            #end
-          #end
-        </ul>
-      </div>
     </div>
-  #end
+    <div class="xwiki-user-profile-body">
+      <ul>
+        #foreach ($property in $properties)
+          #if ($property == 'email')
+            #set ($icon = 'envelope')
+          #elseif ($property == 'phone')
+            #set ($icon = 'phone')
+          #elseif ($property == 'company')
+            #set ($icon = 'building')
+          #else
+            #set ($icon = $NULL)
+          #end
+          #set ($propertyValue = $userObj.getValue($property))
+          #if ("$!propertyValue" != '')
+            <li>
+              #if ($icon != $NULL)
+                <span class="xwiki-user-profile-attribute-icon">$services.icon.renderHTML($icon)</span>
+              #end
+              #stripHTML($userPage.display($property, 'view'))
+            </li>
+          #end
+        #end
+      </ul>
+    </div>
+  </div>
+#else
+  <div class="box warningmessage">
+    $services.localization.render('rendering.macro.userProfile.parameter.reference.isInvalid')
+  </div>
 #end

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreference/view.vm
@@ -44,30 +44,32 @@
         </div>
       </div>
     </div>
-    <div class="xwiki-user-profile-body">
-      <ul>
-        #foreach ($property in $properties)
-          #if ($property == 'email')
-            #set ($icon = 'envelope')
-          #elseif ($property == 'phone')
-            #set ($icon = 'phone')
-          #elseif ($property == 'company')
-            #set ($icon = 'building')
-          #else
-            #set ($icon = $NULL)
+    #if ($!displayer.parameters.properties != '')
+      <div class="xwiki-user-profile-body">
+        <ul>
+          #foreach ($property in $properties)
+            #if ($property == 'email')
+              #set ($icon = 'envelope')
+            #elseif ($property == 'phone')
+              #set ($icon = 'phone')
+            #elseif ($property == 'company')
+              #set ($icon = 'building')
+            #else
+              #set ($icon = $NULL)
+            #end
+            #set ($propertyValue = $userObj.getValue($property))
+            #if ("$!propertyValue" != '')
+              <li>
+                #if ($icon != $NULL)
+                  <span class="xwiki-user-profile-attribute-icon">$services.icon.renderHTML($icon)</span>
+                #end
+                #stripHTML($userPage.display($property, 'view'))
+              </li>
+            #end
           #end
-          #set ($propertyValue = $userObj.getValue($property))
-          #if ("$!propertyValue" != '')
-            <li>
-              #if ($icon != $NULL)
-                <span class="xwiki-user-profile-attribute-icon">$services.icon.renderHTML($icon)</span>
-              #end
-              #stripHTML($userPage.display($property, 'view'))
-            </li>
-          #end
-        #end
-      </ul>
-    </div>
+        </ul>
+      </div>
+    #end
   </div>
 #else
   <div class="box warningmessage">

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Macros.Translations" locale="">
+<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="">
   <web>XWiki.Macros</web>
   <name>Translations</name>
   <language/>
@@ -29,6 +29,7 @@
   <creator>xwiki:XWiki.Admin</creator>
   <parent>xwiki:XWiki.Macros.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
+  <originalMetadataAuthor>XWiki.superadmin</originalMetadataAuthor>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
   <title>Translations</title>
@@ -105,7 +106,17 @@ rendering.macro.microsoftStream.parameter.start.description=Start video at a spe
 rendering.macro.microsoftStream.parameter.showinfo.name=Show Info
 rendering.macro.microsoftStream.parameter.showinfo.description=Show the video info on thumbnail.
 rendering.macro.microsoftStream.parameter.autoplay.name=Auto Play
-rendering.macro.microsoftStream.parameter.autoplay.description=Whether the video should start automatically or if the user must play it.</content>
+rendering.macro.microsoftStream.parameter.autoplay.description=Whether the video should start automatically or if the user must play it.
+
+## User Profile macro
+rendering.macro.userProfile.name=User Profile
+rendering.macro.userProfile.description=Displays a user profile with custom properties
+rendering.macro.userProfile.parameter.reference.name=User
+rendering.macro.userProfile.parameter.reference.description=Reference to a user page
+rendering.macro.userProfile.parameter.properties.name=User properties
+rendering.macro.userProfile.parameter.properties.description=List of user properties to be displayed, separated by a comma
+rendering.macro.userProfile.parameter.reference.isInvalid=The User Profile macro &lt;em&gt;reference&lt;/em&gt; parameter is either missing or invalid.
+</content>
   <object>
     <name>XWiki.Macros.Translations</name>
     <number>0</number>
@@ -124,6 +135,8 @@ rendering.macro.microsoftStream.parameter.autoplay.description=Whether the video
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
         <number>1</number>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -29,7 +29,6 @@
   <creator>xwiki:XWiki.Admin</creator>
   <parent>xwiki:XWiki.Macros.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <originalMetadataAuthor>XWiki.superadmin</originalMetadataAuthor>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
   <title>Translations</title>
@@ -141,7 +140,7 @@ rendering.macro.userProfile.parameter.reference.name=User
 rendering.macro.userProfile.parameter.reference.description=Reference to a user page
 rendering.macro.userProfile.parameter.properties.name=User properties
 rendering.macro.userProfile.parameter.properties.description=List of user properties to be displayed, separated by a comma
-rendering.macro.userProfile.parameter.reference.isInvalid=The User Profile macro &lt;em&gt;reference&lt;/em&gt; parameter is either missing or invalid.</content>
+rendering.macro.userProfile.parameter.reference.isInvalid=The User Profile macro "reference" parameter is either missing or invalid.</content>
   <object>
     <name>XWiki.Macros.Translations</name>
     <number>0</number>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="">
+<xwikidoc version="1.3" reference="XWiki.Macros.Translations" locale="">
   <web>XWiki.Macros</web>
   <name>Translations</name>
   <language/>
@@ -159,8 +159,6 @@ rendering.macro.userProfile.parameter.reference.isInvalid=The User Profile macro
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
         <number>1</number>


### PR DESCRIPTION
This pull request adds a UserProfile macro (id: `userProfile`) with its parameter class, custom displayer and translation entries. The list of displayed properties can be customized using the `properties` macro parameter. Here's below how it renders currently, with a user picker on edit. It is styled by the stylesheet `css/userprofile.css`. That'd be better to use a LESS stylesheet so as to use some of the current theme colors but I could not find how to do this in this context for now. I will try to investigate, any hint welcome.


![userprofile](https://user-images.githubusercontent.com/1022195/188451601-ba81eb87-36fc-497c-8c9a-e69442923092.png)




