### PR TITLE
Add Attachments macro (#82)

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -1,0 +1,944 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.5" reference="Confluence.Macros.Attachments" locale="">
+  <web>Confluence.Macros</web>
+  <name>Attachments</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <originalMetadataAuthor>XWiki.Admin</originalMetadataAuthor>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>Attachments</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>The Attachment macro is a bridge between Confluence and XWiki. It uses the XWiki implementation to display attachments in the page content. There are two things to note:
+
+Not every parameters supported by the Confluence macro are supported by this bridge macro. The remaining parameters are ignored:
+
+* {{{ labels }}} is not supported since XWiki does not support attachment tags
+* {{{ preview }}} does not make sense for the XWiki macro as attachments are displayed differently
+* {{{ old }}} has not been implemented in this bridge macro because it does not make really sense for XWiki
+* {{{ "created date" }}} value of the {{{ sortBy }}} property behave the same way as the {{{ "date" }}} value
+
+= Parameters =
+
+|=Parameter|=Description|=Required|=Default
+|**patterns**|Comma-separated list of regular expressions, used to filter attachments by name.|No| 
+|**sortBy**|Sort attachments by {{{ date }}}, {{{ size }}} or {{{ name }}}|No|{{{ date }}}
+|**sortOrder**|Sort attachments in {{{ ascending }}} or {{{ descending }}} order|No|{{{ ascending }}}
+|**upload**|Allow users to attach new files|No|{{{ true }}}
+|**page**|Pages containing the attachments to display. Current page if empty.|No| 
+
+= Example Usage =
+
+
+{{code}}
+{{attachments
+  patterns=".*png"
+  sortBy="name"
+/}}
+{{/code}}</content>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>0</number>
+    <className>XWiki.StyleSheetExtension</className>
+    <guid>8a8f1c65-649d-41b2-ab48-778c676f24cd</guid>
+    <class>
+      <name>XWiki.StyleSheetExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>.confluence-attachment-macro {
+  .upload-response {
+    display: none;
+  }
+  #attachform {
+    .buttonwrapper {
+      display: none;
+    }
+  }
+}</code>
+    </property>
+    <property>
+      <contentType>LESS</contentType>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroClass</className>
+    <guid>e02a27df-6c8d-42bb-85cf-8a9eb6f3d6fe</guid>
+    <class>
+      <name>XWiki.WikiMacroClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>13</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>14</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>12</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
+      <code>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>code</name>
+        <number>10</number>
+        <prettyName>Macro code</prettyName>
+        <rows>20</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentDescription>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>contentDescription</name>
+        <number>9</number>
+        <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </contentDescription>
+      <contentJavaType>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentJavaType</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentJavaType>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>7</number>
+        <prettyName>Macro content availability</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Optional|Mandatory|No content</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <defaultCategory>
+        <disabled>0</disabled>
+        <name>defaultCategory</name>
+        <number>4</number>
+        <prettyName>Default category</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultCategory>
+      <description>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>description</name>
+        <number>3</number>
+        <prettyName>Macro description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <id>
+        <disabled>0</disabled>
+        <name>id</name>
+        <number>1</number>
+        <prettyName>Macro id</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </id>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Macro name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
+      <supportsInlineMode>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>supportsInlineMode</name>
+        <number>5</number>
+        <prettyName>Supports inline mode</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </supportsInlineMode>
+      <visibility>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>visibility</name>
+        <number>6</number>
+        <prettyName>Macro visibility</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Current User|Current Wiki|Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </visibility>
+    </class>
+    <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
+    <property>
+      <code>{{html clean="false"}}
+  &lt;div class="confluence-attachment-macro"&gt;
+{{/html}}
+{{velocity output="false"}}
+$xwiki.ssx.use('Confluence.Macros.Attachments')
+#if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
+#template('attachment_macros.vm')
+#set ($attachments = $doc.attachmentList)
+#if ("$!wikimacro.parameters.page" != '')
+  #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
+  #set ($attachments = $document.attachmentList)
+#end
+#set ($confluencePatterns = "$!wikimacro.parameters.patterns")
+#if ($confluencePatterns == '')
+  #set($attachmentsFiltered = $attachments)
+#else
+  #set ($patterns = $!confluencePatterns.split(','))
+  #set($attachmentsFiltered = [])
+  #foreach ($attachment in $attachments)
+    #foreach ($pattern in $patterns)
+      #set ($matches = $attachment.filename.matches("(?i)$!pattern"))
+      #if ($matches)
+        #set ($discard = $attachmentsFiltered.add($attachment))
+        #break
+      #end
+    #end
+  #end
+#end
+{{/velocity}}
+{{velocity}}
+## Sort attachments
+#set ($confluenceSortBy = "$!wikimacro.parameters.sortBy")
+#if ($confluenceSortBy == 'date')
+  #set ($sortBy = 'date')
+#elseif ($confluenceSortBy == 'size')
+  #set ($sortBy = 'filesize')
+#elseif ($confluenceSortBy == 'name')
+  #set ($sortBy = 'filename')
+#elseif ($confluenceSortBy == 'creation date')
+  #set ($sortBy = 'date')
+#else
+{{warning}}
+Warning: sortBy parameter must be one of 'date', 'size', or 'name'
+{{/warning}}
+#end
+#set ($confluenceSortOrder = "$!wikimacro.parameters.sortOrder")
+#set ($reverseOrderProperties = ['filesize', 'date'])
+#if ($confluenceSortOrder == 'ascending')
+  #if ($reverseOrderProperties.contains($sortBy))
+    #set ($sortOrder = 'desc')
+  #else
+    #set ($sortOrder = 'asc')
+  #end
+#elseif ($confluenceSortOrder == 'descending')
+  #if ($reverseOrderProperties.contains($sortBy))
+    #set ($sortOrder = 'asc')
+  #else
+    #set ($sortOrder = 'desc')
+  #end
+#else
+{{warning}}
+Warning: sortOrder parameter must be one of 'ascending' or 'descending'
+{{/warning}}
+#end
+#set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
+{{html clean="false"}}
+#if ($attachmentsFiltered.size() &gt; 0)
+  #displayAttachments($attachmentsFiltered)
+  #deleteAttachmentModal()
+#else
+  &lt;p class="noitems"&gt;$services.localization.render('core.viewers.attachments.noAttachments')&lt;/p&gt;
+#end
+{{/html}}
+## Allow upload
+#set ($upload = "$!wikimacro.parameters.upload")
+#if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin))
+
+
+  {{html}}
+    &lt;form action="$doc.getURL("upload")" enctype="multipart/form-data" method="post" id="AddAttachment"&gt;
+    &lt;div&gt;
+    ## CSRF prevention
+    &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+    ## $redirect is defined in attachmentslist.vm
+    &lt;input type="hidden" name="xredirect" value="$escapetool.xml($redirect)" /&gt;
+    &lt;fieldset id="attachform"&gt;
+      &lt;legend&gt;$services.localization.render('core.viewers.attachments.upload.title')&lt;/legend&gt;
+      ## Temporarily disabled, until we fix attachment name handling
+      ## &lt;div&gt;&lt;label id="xwikiuploadnamelabel" for="xwikiuploadname"&gt;$services.localization.render('core.viewers.attachments.upload.filename')&lt;/label&gt;&lt;/div&gt;
+      ## &lt;div&gt;&lt;input id="xwikiuploadname" type="hidden" name="filename" value="" size="40"/&gt;&lt;/div&gt;
+      &lt;div class="fileupload-field"&gt;
+        &lt;label class="hidden" for="xwikiuploadfile"&gt;$services.localization.render('core.viewers.attachments.upload.file')&lt;/label&gt;
+        &lt;input id="xwikiuploadfile" type="file" name="filepath" size="40" class="uploadFileInput noitems" data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" /&gt;
+      &lt;/div&gt;
+      &lt;div&gt;
+        &lt;span class="buttonwrapper"&gt;
+          &lt;input type="submit" value="$services.localization.render('core.viewers.attachments.upload.submit')" class="button btn btn-primary"/&gt;
+        &lt;/span&gt;
+        &lt;span class="buttonwrapper"&gt;
+          &lt;a class="cancel secondary button btn btn-primary" href="$doc.getURL()"&gt;$services.localization.render('core.viewers.attachments.upload.cancel')&lt;/a&gt;
+        &lt;/span&gt;
+      &lt;/div&gt;
+    &lt;/fieldset&gt;
+    &lt;/div&gt;
+    &lt;/form&gt;
+  {{/html}}
+#end
+{{/velocity}}
+
+{{html clean="false"}}
+  &lt;/div&gt; &lt;!-- .confluence-attachment-macro --&gt;
+{{/html}}
+</code>
+    </property>
+    <property>
+      <contentDescription/>
+    </property>
+    <property>
+      <contentJavaType/>
+    </property>
+    <property>
+      <contentType>No content</contentType>
+    </property>
+    <property>
+      <defaultCategory>confluence</defaultCategory>
+    </property>
+    <property>
+      <description/>
+    </property>
+    <property>
+      <id>attachments</id>
+    </property>
+    <property>
+      <name>attachments</name>
+    </property>
+    <property>
+      <priority/>
+    </property>
+    <property>
+      <supportsInlineMode>0</supportsInlineMode>
+    </property>
+    <property>
+      <visibility>Current Wiki</visibility>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>d584bdf4-8906-4c1c-bcf5-1a89a66021d4</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>A comma-separated list of regular expressions, used to filter the attachments by file name. Note that the parameter values must be regular expressions. For example:
+
+* To match a file suffix of 'jpg', use .*jpg (not *.jpg).
+* To match file names ending in 'jpg' or 'png', use .*jpg,.*png
+
+ </description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>patterns</name>
+    </property>
+    <property>
+      <type>java.lang.String</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>3</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>28669705-3ae4-42f3-bd3b-0ac932622b2e</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>true</defaultValue>
+    </property>
+    <property>
+      <description>If selected, the list of attachments will include options allowing users to browse for, and attach, new files.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>upload</name>
+    </property>
+    <property>
+      <type>java.lang.Boolean</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>4</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>fef28103-46af-42a6-8adf-6ce3c11f2b89</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>Used to display attachments from another page. If you do not enter a page title, the macro will display the files attached to the current page.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>page</name>
+    </property>
+    <property>
+      <type>java.lang.String</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>6</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>cad81f19-33ce-436f-8081-c09b16ce15c4</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>date</defaultValue>
+    </property>
+    <property>
+      <description>The sort order for attachments. Note that people viewing the page can change the sort order by clicking the column headings. Valid values are:
+
+* **date** – sorts by updated date in reverse chronological order (newest first)
+* **size** – sorts largest to smallest
+* **name** – sorts alphabetically
+* **created date** - sorts by creation date in reverse chronological order (newest first)</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>sortBy</name>
+    </property>
+    <property>
+      <type>java.lang.String</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>7</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>edc47918-b2af-411b-9fb4-9c7c55d30f94</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>ascending</defaultValue>
+    </property>
+    <property>
+      <description>Used in combination with the **Sort By** parameter, to sort the attachments in ascending or descending order.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>sortOrder</name>
+    </property>
+    <property>
+      <type>java.lang.String</type>
+    </property>
+  </object>
+</xwikidoc>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -501,10 +501,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{html clean="false"}}
-  &lt;div class="confluence-attachment-macro"&gt;
-{{/html}}
-{{velocity output="false"}}
+      <code>{{velocity output="false"}}
 $xwiki.ssx.use('Confluence.Macros.Attachments')
 $xwiki.jsx.use('Confluence.Macros.Attachments')
 #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
@@ -547,10 +544,9 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
     #end
   #end
 #end
-{{/velocity}}
-{{velocity}}
 ## Sort attachments
 #set ($confluenceSortBy = "$!wikimacro.parameters.sortBy")
+#set ($invalidSortBy = false)
 #if ($confluenceSortBy == 'date')
   #set ($sortBy = 'date')
 #elseif ($confluenceSortBy == 'size')
@@ -560,86 +556,127 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
 #elseif ($confluenceSortBy == 'creation date')
   #set ($sortBy = 'date')
 #else
-{{warning}}
-Warning: sortBy parameter must be one of 'date', 'size', or 'name'
-{{/warning}}
+  #set ($invalidSortBy = true)
 #end
 #set ($confluenceSortOrder = "$!wikimacro.parameters.sortOrder")
-#set ($reverseOrderProperties = ['filesize', 'date'])
+#set ($invalidSortOrder = false)
+#set ($reverseSortOrderProperties = ['filesize', 'date'])
 #if ($confluenceSortOrder == 'ascending')
-  #if ($reverseOrderProperties.contains($sortBy))
+  #if ($reverseSortOrderProperties.contains($sortBy))
     #set ($sortOrder = 'desc')
   #else
     #set ($sortOrder = 'asc')
   #end
 #elseif ($confluenceSortOrder == 'descending')
-  #if ($reverseOrderProperties.contains($sortBy))
+  #if ($reverseSortOrderProperties.contains($sortBy))
     #set ($sortOrder = 'asc')
   #else
     #set ($sortOrder = 'desc')
   #end
 #else
-{{warning}}
-Warning: sortOrder parameter must be one of 'ascending' or 'descending'
-{{/warning}}
+  #set ($invalidSortOrder = false)
 #end
 #set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
-## Display attchments
-{{html clean="false"}}
-#if ($attachmentsFiltered.size() &gt; 0)
-  #displayAttachments($attachmentsFiltered)
-  #deleteAttachmentModal()
-#else
-  &lt;p class="noitems"&gt;
-    $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
-  &lt;/p&gt;
-#end
-{{/html}}
-## Allow upload
-#set ($upload = "$!wikimacro.parameters.upload")
-#if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
-
-
-  {{html}}
-    &lt;form action="$doc.getURL("upload")" enctype="multipart/form-data" method="post" id="AddAttachment"&gt;
-    &lt;div&gt;
-    ## CSRF prevention
-    &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
-    ## $redirect is defined in attachmentslist.vm
-    &lt;input type="hidden" name="xredirect" value="$escapetool.xml($redirect)" /&gt;
-    &lt;fieldset id="attachform"&gt;
-      &lt;legend&gt;
-        $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
-      &lt;/legend&gt;
-      ## Temporarily disabled, until we fix attachment name handling
-      ## &lt;div&gt;&lt;label id="xwikiuploadnamelabel" for="xwikiuploadname"&gt;$services.localization.render('core.viewers.attachments.upload.filename')&lt;/label&gt;&lt;/div&gt;
-      ## &lt;div&gt;&lt;input id="xwikiuploadname" type="hidden" name="filename" value="" size="40"/&gt;&lt;/div&gt;
-      &lt;div class="fileupload-field"&gt;
-        &lt;label class="hidden" for="xwikiuploadfile"&gt;
-          $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
-        &lt;/label&gt;
-        &lt;input id="xwikiuploadfile" type="file" name="filepath" size="40" class="uploadFileInput noitems" data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" /&gt;
-      &lt;/div&gt;
-      &lt;div&gt;
-        &lt;span class="buttonwrapper"&gt;
-          &lt;input type="submit" value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))" class="button btn btn-primary"/&gt;
-        &lt;/span&gt;
-        &lt;span class="buttonwrapper"&gt;
-          &lt;a class="cancel secondary button btn btn-primary" href="$doc.getURL()"&gt;
-            $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
-          &lt;/a&gt;
-        &lt;/span&gt;
-      &lt;/div&gt;
-    &lt;/fieldset&gt;
-    &lt;/div&gt;
-    &lt;/form&gt;
-  {{/html}}
-#end
 {{/velocity}}
-
+{{velocity}}
+#if ($invalidSortBy)
+  {{error}}
+    Attachment macro error: sortBy parameter must be one of 'date', 'size', or 'name'
+  {{/error}}
+  #break
+#end
+#if ($invalidSortOrder)
+  {{error}}
+    Attachment macro error: sortOrder parameter must be one of 'ascending' or 'descending'
+  {{/error}}
+  #break
+#end
+## Display attachments
 {{html clean="false"}}
-  &lt;/div&gt; &lt;!-- .confluence-attachment-macro --&gt;
+  &lt;div class="confluence-attachment-macro"&gt;
+    #if ($attachmentsFiltered.size() &gt; 0)
+      #displayAttachments($attachmentsFiltered)
+      #deleteAttachmentModal()
+    #else
+      &lt;p class="noitems"&gt;
+        $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
+      &lt;/p&gt;
+    #end
+
+    ## Allow upload
+    #set ($upload = "$!wikimacro.parameters.upload")
+    #if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
+      &lt;br /&gt;
+
+      &lt;form
+        id="AddAttachment"
+        action="$doc.getURL("upload")"
+        method="post"
+        enctype="multipart/form-data"
+      &gt;
+        &lt;div&gt;
+          ## CSRF prevention
+          &lt;input
+            type="hidden"
+            name="form_token"
+            value="$!{services.csrf.getToken()}"
+          /&gt;
+
+          ## $redirect is defined in attachmentslist.vm
+          &lt;input
+            type="hidden"
+            name="xredirect"
+            value="$escapetool.xml($redirect)"
+          /&gt;
+
+          &lt;fieldset id="attachform"&gt;
+            &lt;legend&gt;
+              $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
+            &lt;/legend&gt;
+
+            &lt;div class="fileupload-field"&gt;
+              &lt;label
+                class="hidden"
+                for="xwikiuploadfile"
+              &gt;
+                $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
+              &lt;/label&gt;
+
+              &lt;input
+                id="xwikiuploadfile"
+                class="uploadFileInput noitems"
+                type="file"
+                name="filepath"
+                size="40"
+                data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))"
+              /&gt;
+            &lt;/div&gt;
+
+            &lt;div&gt;
+              &lt;span class="buttonwrapper"&gt;
+                &lt;input
+                  class="button btn btn-primary"
+                  type="submit"
+                  value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))"
+                /&gt;
+              &lt;/span&gt;
+
+              &lt;span class="buttonwrapper"&gt;
+                &lt;a
+                  class="cancel secondary button btn btn-primary"
+                  href="$doc.getURL()"
+                &gt;
+                  $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
+                &lt;/a&gt;
+              &lt;/span&gt;
+            &lt;/div&gt;
+          &lt;/fieldset&gt;
+        &lt;/div&gt;
+      &lt;/form&gt;
+    #end
+  &lt;/div&gt; ## .confluence-attachment-macro
 {{/html}}
+{{/velocity}}
 </code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -519,7 +519,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
   #end
   #set ($attachments = [])
   #foreach ($pageReference in $pageReferenceSet)
-    #set ($document = $xwiki.getDocument("$pageReference"))
+    #set ($document = $xwiki.getDocument($pageReference))
     #set ($documentAttachments = $document.attachmentList)
     #set ($discard = $attachments.addAll($documentAttachments))
   #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -150,11 +150,14 @@ Not every parameters supported by the Confluence macro are supported by this bri
       <cache>long</cache>
     </property>
     <property>
-      <code>document.observe('xwiki:html5upload:message', function (event) {
-  if (event.memo.content === 'UPLOAD_FINISHED' &amp;&amp; event.memo.type === 'done') {
-    location.reload();
-  }
-});</code>
+      <code>require(['jquery', 'xwiki-events-bridge'], function ($) {
+  $('#xwikiuploadfile').on('xwiki:html5upload:message', function (event, data) {
+    if (data.content === 'UPLOAD_FINISHED' &amp;&amp; data.type === 'done') {
+      location.reload();
+    }
+  });
+});
+</code>
     </property>
     <property>
       <name/>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -578,6 +578,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
 #end
 #set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
 {{/velocity}}
+
 {{velocity}}
 #if ($invalidSortBy)
   {{error}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -278,9 +278,14 @@ Not every parameters supported by the Confluence macro are supported by this bri
   .upload-response {
     display: none;
   }
-  #attachform {
-    .buttonwrapper {
-      display: none;
+
+  #AddAttachment {
+    margin-top: 15px;
+
+    #attachform {
+      .buttonwrapper {
+        display: none;
+      }
     }
   }
 }</code>
@@ -607,8 +612,6 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
     ## Allow upload
     #set ($upload = "$!wikimacro.parameters.upload")
     #if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
-      &lt;br /&gt;
-
       &lt;form
         id="AddAttachment"
         action="$doc.getURL("upload")"

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -622,13 +622,6 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
             value="$!{services.csrf.getToken()}"
           /&gt;
 
-          ## $redirect is defined in attachmentslist.vm
-          &lt;input
-            type="hidden"
-            name="xredirect"
-            value="$escapetool.xml($redirect)"
-          /&gt;
-
           &lt;fieldset id="attachform"&gt;
             &lt;legend&gt;
               $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -67,6 +67,109 @@ Not every parameters supported by the Confluence macro are supported by this bri
   <object>
     <name>Confluence.Macros.Attachments</name>
     <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>3d368173-f007-4ddb-830f-f475821ff8d8</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>document.observe('xwiki:html5upload:message', function (event) {
+  if (event.memo.content === 'UPLOAD_FINISHED' &amp;&amp; event.memo.type === 'done') {
+    location.reload();
+  }
+});</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>0</number>
     <className>XWiki.StyleSheetExtension</className>
     <guid>8a8f1c65-649d-41b2-ab48-778c676f24cd</guid>
     <class>
@@ -401,6 +504,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
 {{/html}}
 {{velocity output="false"}}
 $xwiki.ssx.use('Confluence.Macros.Attachments')
+$xwiki.jsx.use('Confluence.Macros.Attachments')
 #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
 #template('attachment_macros.vm')
 #set ($attachments = $doc.attachmentList)
@@ -471,7 +575,7 @@ Warning: sortOrder parameter must be one of 'ascending' or 'descending'
 {{/html}}
 ## Allow upload
 #set ($upload = "$!wikimacro.parameters.upload")
-#if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin))
+#if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
 
 
   {{html}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -29,7 +29,6 @@
   <creator>xwiki:XWiki.Admin</creator>
   <parent>WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
-  <originalMetadataAuthor>XWiki.Admin</originalMetadataAuthor>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
   <title>Attachments</title>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -507,11 +507,28 @@ $xwiki.ssx.use('Confluence.Macros.Attachments')
 $xwiki.jsx.use('Confluence.Macros.Attachments')
 #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
 #template('attachment_macros.vm')
-#set ($attachments = $doc.attachmentList)
-#if ("$!wikimacro.parameters.page" != '')
-  #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
-  #set ($attachments = $document.attachmentList)
+## Get attachments
+#if ("$!wikimacro.parameters.tags" != '')
+  #set ($tags = $!wikimacro.parameters.tags.split(','))
+  #set ($pageReferenceSet = $collectiontool.getSet())
+  #foreach ($tag in $tags)
+    #set ($references = $xwiki.tag.getDocumentsWithTag("$tag"))
+    #set ($discard = $pageReferenceSet.addAll($references))
+  #end
+  #set ($attachments = [])
+  #foreach ($pageReference in $pageReferenceSet)
+    #set ($document = $xwiki.getDocument("$pageReference"))
+    #set ($documentAttachments = $document.attachmentList)
+    #set ($discard = $attachments.addAll($documentAttachments))
+  #end
+#else
+  #set ($attachments = $doc.attachmentList)
+  #if ("$!wikimacro.parameters.page" != '')
+    #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
+    #set ($attachments = $document.attachmentList)
+  #end
 #end
+## Filter attachments
 #set ($confluencePatterns = "$!wikimacro.parameters.patterns")
 #if ($confluencePatterns == '')
   #set($attachmentsFiltered = $attachments)
@@ -565,6 +582,7 @@ Warning: sortOrder parameter must be one of 'ascending' or 'descending'
 {{/warning}}
 #end
 #set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
+## Display attchments
 {{html clean="false"}}
 #if ($attachmentsFiltered.size() &gt; 0)
   #displayAttachments($attachmentsFiltered)
@@ -1040,6 +1058,84 @@ Warning: sortOrder parameter must be one of 'ascending' or 'descending'
     </property>
     <property>
       <name>sortOrder</name>
+    </property>
+    <property>
+      <type>java.lang.String</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>8</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>e1ae4f9d-5f3c-4059-b14b-573e4069241a</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>A list of comma-separated wiki tags, used to display attachments from pages matching all given tags. If you do not enter tags, the macro will display the files attached to the current page. When used, ~{~{~{ page }}} property is ignored.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>tags</name>
     </property>
     <property>
       <type>java.lang.String</type>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -685,13 +685,13 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
       <defaultCategory>confluence</defaultCategory>
     </property>
     <property>
-      <description/>
+      <description>Confluence attachment macro support for XWiki</description>
     </property>
     <property>
-      <id>attachments</id>
+      <id>confluence_attachments</id>
     </property>
     <property>
-      <name>attachments</name>
+      <name>Attachments</name>
     </property>
     <property>
       <priority/>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -590,7 +590,9 @@ Warning: sortOrder parameter must be one of 'ascending' or 'descending'
   #displayAttachments($attachmentsFiltered)
   #deleteAttachmentModal()
 #else
-  &lt;p class="noitems"&gt;$services.localization.render('core.viewers.attachments.noAttachments')&lt;/p&gt;
+  &lt;p class="noitems"&gt;
+    $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
+  &lt;/p&gt;
 #end
 {{/html}}
 ## Allow upload
@@ -606,20 +608,26 @@ Warning: sortOrder parameter must be one of 'ascending' or 'descending'
     ## $redirect is defined in attachmentslist.vm
     &lt;input type="hidden" name="xredirect" value="$escapetool.xml($redirect)" /&gt;
     &lt;fieldset id="attachform"&gt;
-      &lt;legend&gt;$services.localization.render('core.viewers.attachments.upload.title')&lt;/legend&gt;
+      &lt;legend&gt;
+        $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
+      &lt;/legend&gt;
       ## Temporarily disabled, until we fix attachment name handling
       ## &lt;div&gt;&lt;label id="xwikiuploadnamelabel" for="xwikiuploadname"&gt;$services.localization.render('core.viewers.attachments.upload.filename')&lt;/label&gt;&lt;/div&gt;
       ## &lt;div&gt;&lt;input id="xwikiuploadname" type="hidden" name="filename" value="" size="40"/&gt;&lt;/div&gt;
       &lt;div class="fileupload-field"&gt;
-        &lt;label class="hidden" for="xwikiuploadfile"&gt;$services.localization.render('core.viewers.attachments.upload.file')&lt;/label&gt;
+        &lt;label class="hidden" for="xwikiuploadfile"&gt;
+          $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
+        &lt;/label&gt;
         &lt;input id="xwikiuploadfile" type="file" name="filepath" size="40" class="uploadFileInput noitems" data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" /&gt;
       &lt;/div&gt;
       &lt;div&gt;
         &lt;span class="buttonwrapper"&gt;
-          &lt;input type="submit" value="$services.localization.render('core.viewers.attachments.upload.submit')" class="button btn btn-primary"/&gt;
+          &lt;input type="submit" value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))" class="button btn btn-primary"/&gt;
         &lt;/span&gt;
         &lt;span class="buttonwrapper"&gt;
-          &lt;a class="cancel secondary button btn btn-primary" href="$doc.getURL()"&gt;$services.localization.render('core.viewers.attachments.upload.cancel')&lt;/a&gt;
+          &lt;a class="cancel secondary button btn btn-primary" href="$doc.getURL()"&gt;
+            $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
+          &lt;/a&gt;
         &lt;/span&gt;
       &lt;/div&gt;
     &lt;/fieldset&gt;

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -776,10 +776,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
       <defaultValue/>
     </property>
     <property>
-      <description>A comma-separated list of regular expressions, used to filter the attachments by file name. Note that the parameter values must be regular expressions. For example:
-
-* To match a file suffix of 'jpg', use .*jpg (not *.jpg).
-* To match file names ending in 'jpg' or 'png', use .*jpg,.*png
+      <description>A comma-separated list of regular expressions, used to filter the attachments by file name. Note that the parameter values must be regular expressions. For example: to match a file suffix of 'jpg', use '.*jpg' (not '*.jpg'); to match file names ending in 'jpg' or 'png', use '.*jpg,.*png'
 
  </description>
     </property>
@@ -1015,12 +1012,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
       <defaultValue>date</defaultValue>
     </property>
     <property>
-      <description>The sort order for attachments. Note that people viewing the page can change the sort order by clicking the column headings. Valid values are:
-
-* **date** – sorts by updated date in reverse chronological order (newest first)
-* **size** – sorts largest to smallest
-* **name** – sorts alphabetically
-* **created date** - sorts by creation date in reverse chronological order (newest first)</description>
+      <description>The sort order for attachments. Note that people viewing the page can change the sort order by clicking the column headings. Valid values are: 'date' - sorts by updated date in reverse chronological order (newest first); 'size' - sorts largest to smallest; 'name' - sorts alphabetically</description>
     </property>
     <property>
       <mandatory>0</mandatory>
@@ -1098,7 +1090,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
       <defaultValue>ascending</defaultValue>
     </property>
     <property>
-      <description>Used in combination with the **Sort By** parameter, to sort the attachments in ascending or descending order.</description>
+      <description>Used in combination with the Sort By parameter, to sort the attachments in ascending or descending order.</description>
     </property>
     <property>
       <mandatory>0</mandatory>
@@ -1176,7 +1168,7 @@ $xwiki.jsx.use('Confluence.Macros.Attachments')
       <defaultValue/>
     </property>
     <property>
-      <description>A list of comma-separated wiki tags, used to display attachments from pages matching all given tags. If you do not enter tags, the macro will display the files attached to the current page. When used, ~{~{~{ page }}} property is ignored.</description>
+      <description>A list of comma-separated wiki tags, used to display attachments from pages matching all given tags. If you do not enter tags, the macro will display the files attached to the current page. When used, 'page' property is ignored.</description>
     </property>
     <property>
       <mandatory>0</mandatory>


### PR DESCRIPTION
This pull request adds support for the Attachment macro from confluence  (#82).

Possible improvements (discussed with @snazare, more input welcomed):
- Refresh attachment list when adding new attachments. There are two possibilities:
  - reload page automatically when adding new attachments (and remove the add button in edit mode)
  - use the dynamic attachments display from javascript
- Remove duplicate `addAttachments` html tag ids in page (due to reusing code from `attachments_macro.vm`)
- Add a parameter to display attachments from pages matching the given labels. Would work like the `page` parameter, but for several pages, and could be an alternative for the `labels` parameter which is not supported in XWiki.