### PR TITLE
Add warning when adding macros without a license #110

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Anchor.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Anchor.xml
@@ -275,8 +275,19 @@ Link to the anchor: [[link&gt;&gt;||anchor="test"]]</content>
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-{{id name="$wikimacro.parameters.name" /}}
+      <code>{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  {{id name="$wikimacro.parameters.name" /}}
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -507,7 +507,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
     </property>
     <property>
       <code>{{velocity output="false"}}
-#macro (filterAndSortAttachments)
+#macro (filterAndSortAttachments $attachmentsFiltered $invalidSortBy $invalidSortOrder)
   $xwiki.ssx.use('Confluence.Macros.Attachments')
   $xwiki.jsx.use('Confluence.Macros.Attachments')
   #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -507,172 +507,190 @@ Not every parameters supported by the Confluence macro are supported by this bri
     </property>
     <property>
       <code>{{velocity output="false"}}
-$xwiki.ssx.use('Confluence.Macros.Attachments')
-$xwiki.jsx.use('Confluence.Macros.Attachments')
-#if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
-#template('attachment_macros.vm')
-## Get attachments
-#if ("$!wikimacro.parameters.tags" != '')
-  #set ($tags = $!wikimacro.parameters.tags.split(','))
-  #set ($pageReferenceSet = $collectiontool.getSet())
-  #foreach ($tag in $tags)
-    #set ($references = $xwiki.tag.getDocumentsWithTag("$tag"))
-    #set ($discard = $pageReferenceSet.addAll($references))
+#macro (filterAndSortAttachments)
+  $xwiki.ssx.use('Confluence.Macros.Attachments')
+  $xwiki.jsx.use('Confluence.Macros.Attachments')
+  #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
+  #template('attachment_macros.vm')
+  ## Get attachments
+  #if ("$!wikimacro.parameters.tags" != '')
+    #set ($tags = $!wikimacro.parameters.tags.split(','))
+    #set ($pageReferenceSet = $collectiontool.getSet())
+    #foreach ($tag in $tags)
+      #set ($references = $xwiki.tag.getDocumentsWithTag("$tag"))
+      #set ($discard = $pageReferenceSet.addAll($references))
+    #end
+    #set ($attachments = [])
+    #foreach ($pageReference in $pageReferenceSet)
+      #set ($document = $xwiki.getDocument($pageReference))
+      #set ($documentAttachments = $document.attachmentList)
+      #set ($discard = $attachments.addAll($documentAttachments))
+    #end
+  #else
+    #set ($attachments = $doc.attachmentList)
+    #if ("$!wikimacro.parameters.page" != '')
+      #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
+      #set ($attachments = $document.attachmentList)
+    #end
   #end
-  #set ($attachments = [])
-  #foreach ($pageReference in $pageReferenceSet)
-    #set ($document = $xwiki.getDocument($pageReference))
-    #set ($documentAttachments = $document.attachmentList)
-    #set ($discard = $attachments.addAll($documentAttachments))
-  #end
-#else
-  #set ($attachments = $doc.attachmentList)
-  #if ("$!wikimacro.parameters.page" != '')
-    #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
-    #set ($attachments = $document.attachmentList)
-  #end
-#end
-## Filter attachments
-#set ($confluencePatterns = "$!wikimacro.parameters.patterns")
-#if ($confluencePatterns == '')
-  #set($attachmentsFiltered = $attachments)
-#else
-  #set ($patterns = $!confluencePatterns.split(','))
-  #set($attachmentsFiltered = [])
-  #foreach ($attachment in $attachments)
-    #foreach ($pattern in $patterns)
-      #set ($matches = $attachment.filename.matches("(?i)$!pattern"))
-      #if ($matches)
-        #set ($discard = $attachmentsFiltered.add($attachment))
-        #break
+  ## Filter attachments
+  #set ($confluencePatterns = "$!wikimacro.parameters.patterns")
+  #if ($confluencePatterns == '')
+    #set($attachmentsFiltered = $attachments)
+  #else
+    #set ($patterns = $!confluencePatterns.split(','))
+    #set($attachmentsFiltered = [])
+    #foreach ($attachment in $attachments)
+      #foreach ($pattern in $patterns)
+        #set ($matches = $attachment.filename.matches("(?i)$!pattern"))
+        #if ($matches)
+          #set ($discard = $attachmentsFiltered.add($attachment))
+          #break
+        #end
       #end
     #end
   #end
-#end
-## Sort attachments
-#set ($confluenceSortBy = "$!wikimacro.parameters.sortBy")
-#set ($invalidSortBy = false)
-#if ($confluenceSortBy == 'date')
-  #set ($sortBy = 'date')
-#elseif ($confluenceSortBy == 'size')
-  #set ($sortBy = 'filesize')
-#elseif ($confluenceSortBy == 'name')
-  #set ($sortBy = 'filename')
-#elseif ($confluenceSortBy == 'creation date')
-  #set ($sortBy = 'date')
-#else
-  #set ($invalidSortBy = true)
-#end
-#set ($confluenceSortOrder = "$!wikimacro.parameters.sortOrder")
-#set ($invalidSortOrder = false)
-#set ($reverseSortOrderProperties = ['filesize', 'date'])
-#if ($confluenceSortOrder == 'ascending')
-  #if ($reverseSortOrderProperties.contains($sortBy))
-    #set ($sortOrder = 'desc')
+  ## Sort attachments
+  #set ($confluenceSortBy = "$!wikimacro.parameters.sortBy")
+  #set ($invalidSortBy = false)
+  #if ($confluenceSortBy == 'date')
+    #set ($sortBy = 'date')
+  #elseif ($confluenceSortBy == 'size')
+    #set ($sortBy = 'filesize')
+  #elseif ($confluenceSortBy == 'name')
+    #set ($sortBy = 'filename')
+  #elseif ($confluenceSortBy == 'creation date')
+    #set ($sortBy = 'date')
   #else
-    #set ($sortOrder = 'asc')
+    #set ($invalidSortBy = true)
   #end
-#elseif ($confluenceSortOrder == 'descending')
-  #if ($reverseSortOrderProperties.contains($sortBy))
-    #set ($sortOrder = 'asc')
-  #else
-    #set ($sortOrder = 'desc')
-  #end
-#else
+  #set ($confluenceSortOrder = "$!wikimacro.parameters.sortOrder")
   #set ($invalidSortOrder = false)
+  #set ($reverseSortOrderProperties = ['filesize', 'date'])
+  #if ($confluenceSortOrder == 'ascending')
+    #if ($reverseSortOrderProperties.contains($sortBy))
+      #set ($sortOrder = 'desc')
+    #else
+      #set ($sortOrder = 'asc')
+    #end
+  #elseif ($confluenceSortOrder == 'descending')
+    #if ($reverseSortOrderProperties.contains($sortBy))
+      #set ($sortOrder = 'asc')
+    #else
+      #set ($sortOrder = 'desc')
+    #end
+  #else
+    #set ($invalidSortOrder = false)
+  #end
+  #set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
 #end
-#set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
+
+#macro (executeMacro)
+  #filterAndSortAttachments($attachmentsFiltered $invalidSortBy $invalidSortOrder)
+  #if ($invalidSortBy)
+    {{error}}
+      Attachment macro error: sortBy parameter must be one of 'date', 'size', or 'name'
+    {{/error}}
+    #break
+  #end
+  #if ($invalidSortOrder)
+    {{error}}
+      Attachment macro error: sortOrder parameter must be one of 'ascending' or 'descending'
+    {{/error}}
+    #break
+  #end
+  ## Display attachments
+  {{html clean="false"}}
+    &lt;div class="confluence-attachment-macro"&gt;
+      #if ($attachmentsFiltered.size() &gt; 0)
+        #displayAttachments($attachmentsFiltered)
+        #deleteAttachmentModal()
+      #else
+        &lt;p class="noitems"&gt;
+          $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
+        &lt;/p&gt;
+      #end
+
+      ## Allow upload
+      #set ($upload = "$!wikimacro.parameters.upload")
+      #if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
+        &lt;form
+          id="AddAttachment"
+          action="$doc.getURL("upload")"
+          method="post"
+          enctype="multipart/form-data"
+        &gt;
+          &lt;div&gt;
+            ## CSRF prevention
+            &lt;input
+              type="hidden"
+              name="form_token"
+              value="$!{services.csrf.getToken()}"
+            /&gt;
+
+            &lt;fieldset id="attachform"&gt;
+              &lt;legend&gt;
+                $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
+              &lt;/legend&gt;
+
+              &lt;div class="fileupload-field"&gt;
+                &lt;label
+                  class="hidden"
+                  for="xwikiuploadfile"
+                &gt;
+                  $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
+                &lt;/label&gt;
+
+                &lt;input
+                  id="xwikiuploadfile"
+                  class="uploadFileInput noitems"
+                  type="file"
+                  name="filepath"
+                  size="40"
+                  data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))"
+                /&gt;
+              &lt;/div&gt;
+
+              &lt;div&gt;
+                &lt;span class="buttonwrapper"&gt;
+                  &lt;input
+                    class="button btn btn-primary"
+                    type="submit"
+                    value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))"
+                  /&gt;
+                &lt;/span&gt;
+
+                &lt;span class="buttonwrapper"&gt;
+                  &lt;a
+                    class="cancel secondary button btn btn-primary"
+                    href="$doc.getURL()"
+                  &gt;
+                    $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
+                  &lt;/a&gt;
+                &lt;/span&gt;
+              &lt;/div&gt;
+            &lt;/fieldset&gt;
+          &lt;/div&gt;
+        &lt;/form&gt;
+      #end
+    &lt;/div&gt; ## .confluence-attachment-macro
+  {{/html}}
+#end
 {{/velocity}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-#if ($invalidSortBy)
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
   {{error}}
-    Attachment macro error: sortBy parameter must be one of 'date', 'size', or 'name'
+    #getMissingLicenseMessage('proMacros.extension.name')
   {{/error}}
-  #break
 #end
-#if ($invalidSortOrder)
-  {{error}}
-    Attachment macro error: sortOrder parameter must be one of 'ascending' or 'descending'
-  {{/error}}
-  #break
-#end
-## Display attachments
-{{html clean="false"}}
-  &lt;div class="confluence-attachment-macro"&gt;
-    #if ($attachmentsFiltered.size() &gt; 0)
-      #displayAttachments($attachmentsFiltered)
-      #deleteAttachmentModal()
-    #else
-      &lt;p class="noitems"&gt;
-        $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
-      &lt;/p&gt;
-    #end
-
-    ## Allow upload
-    #set ($upload = "$!wikimacro.parameters.upload")
-    #if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
-      &lt;form
-        id="AddAttachment"
-        action="$doc.getURL("upload")"
-        method="post"
-        enctype="multipart/form-data"
-      &gt;
-        &lt;div&gt;
-          ## CSRF prevention
-          &lt;input
-            type="hidden"
-            name="form_token"
-            value="$!{services.csrf.getToken()}"
-          /&gt;
-
-          &lt;fieldset id="attachform"&gt;
-            &lt;legend&gt;
-              $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
-            &lt;/legend&gt;
-
-            &lt;div class="fileupload-field"&gt;
-              &lt;label
-                class="hidden"
-                for="xwikiuploadfile"
-              &gt;
-                $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
-              &lt;/label&gt;
-
-              &lt;input
-                id="xwikiuploadfile"
-                class="uploadFileInput noitems"
-                type="file"
-                name="filepath"
-                size="40"
-                data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))"
-              /&gt;
-            &lt;/div&gt;
-
-            &lt;div&gt;
-              &lt;span class="buttonwrapper"&gt;
-                &lt;input
-                  class="button btn btn-primary"
-                  type="submit"
-                  value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))"
-                /&gt;
-              &lt;/span&gt;
-
-              &lt;span class="buttonwrapper"&gt;
-                &lt;a
-                  class="cancel secondary button btn btn-primary"
-                  href="$doc.getURL()"
-                &gt;
-                  $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
-                &lt;/a&gt;
-              &lt;/span&gt;
-            &lt;/div&gt;
-          &lt;/fieldset&gt;
-        &lt;/div&gt;
-      &lt;/form&gt;
-    #end
-  &lt;/div&gt; ## .confluence-attachment-macro
-{{/html}}
 {{/velocity}}
 </code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Balsamiq.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Balsamiq.xml
@@ -264,7 +264,8 @@ The wireframe preview is an attachment added to the parent page. For example, fo
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
   ## Macro parameters
   #set($resourceID = $wikimacro.parameters.get('initialResourceID'))
   #set($initialBranchID = $wikimacro.parameters.get('initialBranchID'))
@@ -287,7 +288,22 @@ The wireframe preview is an attachment added to the parent page. For example, fo
       [[image:${attchmentName}]]
     )))
   #end
-{{/velocity}}</code>
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end</code>
     </property>
     <property>
       <contentDescription/>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
@@ -419,22 +419,38 @@ Content in the column 4
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($discard = $xwiki.ssx.use('Confluence.Macros.Column'))
-#set ($style = '')
-#set ($extraCssClass = 'withWidth')
-#if ("$!xcontext.macro.params.width" != '')
-  #set ($style = "style='width: $xcontext.macro.params.width'")
-#end
-(% class="macro-column" $style %)(((
-  ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-  #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-    {{wikimacrocontent /}}
-  #else
-    $!xcontext.macro.content
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('Confluence.Macros.Column'))
+  #set ($style = '')
+  #set ($extraCssClass = 'withWidth')
+  #if ("$!xcontext.macro.params.width" != '')
+    #set ($style = "style='width: $xcontext.macro.params.width'")
   #end
-)))
-{{/velocity}}</code>
+  (% class="macro-column" $style %)(((
+    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+      {{wikimacrocontent /}}
+    #else
+      $!xcontext.macro.content
+    #end
+  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end</code>
     </property>
     <property>
       <contentDescription/>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ConfluenceGallery.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ConfluenceGallery.xml
@@ -317,59 +317,76 @@ The result is the following :
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-## Get the parameters and put them in lists if necessary
-#set ($title = $wikimacro.parameters.title)
-#set ($includeString = $wikimacro.parameters.include)
-#set ($excludeString = $wikimacro.parameters.exclude)
-#set ($pagesString = $wikimacro.parameters.page)
-#set ($include = $includeString.split(','))
-#set ($exclude = $excludeString.split(','))
-#set ($pages = $pagesString.split(','))
-## Display the gallery title if it is set (newlines are needed for the following macro calls to be standalone)
-#if ("$!title" != '')
-  ==$title==
-#end
-## add the current page to the page list if no pages were given
-#if ("$!pagesString" == '')
-  #set ($pages = [$doc.getTitle()])
-#end
-## Collect the attachments to display
-#set ($attachments = [])
-#foreach ($page in $pages)
-  ## Resolve page and put attachments in temporary list
-  #set ($tempAttachments = [])
-  #set ($query = $services.query.xwql('where doc.title = :name').bindValue('name', $page))
-  #set ($pageStrings = $query.execute())
-  #if ($pageStrings.size() &gt; 0)
-    #set ($pageDocument = $xwiki.getDocument($pageStrings[0]))
-    #set ($discard = $tempAttachments.addAll($pageDocument.getAttachmentList()))
-    ## iterate over remaining attachments and add full reference to attachment list
-    #foreach ($attachment in $tempAttachments)
-      #if ($attachment.isImage())
-        ## If includes or excludes are set, only get the desired entries from the temporary attachment list
-        #if ("$!includeString" != '')
-          #if ($include.contains($attachment.filename))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  ## Get the parameters and put them in lists if necessary
+  #set ($title = $wikimacro.parameters.title)
+  #set ($includeString = $wikimacro.parameters.include)
+  #set ($excludeString = $wikimacro.parameters.exclude)
+  #set ($pagesString = $wikimacro.parameters.page)
+  #set ($include = $includeString.split(','))
+  #set ($exclude = $excludeString.split(','))
+  #set ($pages = $pagesString.split(','))
+  ## Display the gallery title if it is set (newlines are needed for the following macro calls to be standalone)
+  #if ("$!title" != '')
+    ==$title==
+  #end
+  ## add the current page to the page list if no pages were given
+  #if ("$!pagesString" == '')
+    #set ($pages = [$doc.getTitle()])
+  #end
+  ## Collect the attachments to display
+  #set ($attachments = [])
+  #foreach ($page in $pages)
+    ## Resolve page and put attachments in temporary list
+    #set ($tempAttachments = [])
+    #set ($query = $services.query.xwql('where doc.title = :name').bindValue('name', $page))
+    #set ($pageStrings = $query.execute())
+    #if ($pageStrings.size() &gt; 0)
+      #set ($pageDocument = $xwiki.getDocument($pageStrings[0]))
+      #set ($discard = $tempAttachments.addAll($pageDocument.getAttachmentList()))
+      ## iterate over remaining attachments and add full reference to attachment list
+      #foreach ($attachment in $tempAttachments)
+        #if ($attachment.isImage())
+          ## If includes or excludes are set, only get the desired entries from the temporary attachment list
+          #if ("$!includeString" != '')
+            #if ($include.contains($attachment.filename))
+              #set ($discard = $attachments.add($pageDocument+'@'+$attachment.filename))
+            #end
+          #elseif ("$!excludeString" != '')
+            #if (!$exclude.contains($attachment.filename))
+              #set ($discard = $attachments.add($pageDocument+'@'+$attachment.filename))
+            #end
+          #else
             #set ($discard = $attachments.add($pageDocument+'@'+$attachment.filename))
           #end
-        #elseif ("$!excludeString" != '')
-          #if (!$exclude.contains($attachment.filename))
-            #set ($discard = $attachments.add($pageDocument+'@'+$attachment.filename))
-          #end
-        #else
-          #set ($discard = $attachments.add($pageDocument+'@'+$attachment.filename))
         #end
       #end
     #end
   #end
-#end
-## Display the attachments in the gallery
-#if ($attachments.size() &gt; 0)
-  {{gallery}}
-  #foreach ($attachment in $attachments)
-    [[image:$attachment]]
+  ## Display the attachments in the gallery
+  #if ($attachments.size() &gt; 0)
+    {{gallery}}
+    #foreach ($attachment in $attachments)
+      [[image:$attachment]]
+    #end
+    {{/gallery}}
   #end
-  {{/gallery}}
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
 {{/velocity}}
 </code>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ContentReportTableMacro.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ContentReportTableMacro.xml
@@ -288,49 +288,66 @@ The result is the following :
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-## Used parameters :
-#set($labels = $wikimacro.parameters.get('labels'))
-#set($spaces = $wikimacro.parameters.get('spaces'))
-#set($maxResults = $wikimacro.parameters.get('maxResults'))
-#if("$!maxResults" == '')
-  #set($maxResults = 20)
-#end
-## Searching for the matching pages
-#set($statement = 'select distinct doc.fullName, doc.title, doc.creator, doc.date from XWikiDocument doc, BaseObject as obj, DBStringListProperty as prop
-                   join prop.list item where obj.className = :className and obj.name = doc.fullName and obj.id = prop.id.id
-                   and prop.id.name = :propName  and lower(item) in (:labelsList)')
-#set($lowerCaseLabelList = [])
-#foreach($label in $labels.split(','))
-  #set($discard = $lowerCaseLabelList.add($label.toLowerCase()))
-#end
-#set($params = {
-  'className': 'XWiki.TagClass',
-  'propName': 'tags',
-  'labelsList': $lowerCaseLabelList
-})
-#if("$!spaces" != '')
-  #set ($statement = $statement + ' and (')
-  #foreach($space in $spaces.split('(?&lt;!\\\\), '))
-    #if($foreach.index &gt; 0)
-      #set($statement = $statement + ' or ')
-    #end
-    #set($statement = $statement + "doc.space like :space$foreach.index")
-    #set($discard = $params.put("space$foreach.index", $space.replaceAll('([%_!])', '!$1').concat('%')))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  ## Used parameters :
+  #set($labels = $wikimacro.parameters.get('labels'))
+  #set($spaces = $wikimacro.parameters.get('spaces'))
+  #set($maxResults = $wikimacro.parameters.get('maxResults'))
+  #if("$!maxResults" == '')
+    #set($maxResults = 20)
   #end
-  #set($statement = $statement + ')')
+  ## Searching for the matching pages
+  #set($statement = 'select distinct doc.fullName, doc.title, doc.creator, doc.date from XWikiDocument doc, BaseObject as obj, DBStringListProperty as prop
+                     join prop.list item where obj.className = :className and obj.name = doc.fullName and obj.id = prop.id.id
+                     and prop.id.name = :propName  and lower(item) in (:labelsList)')
+  #set($lowerCaseLabelList = [])
+  #foreach($label in $labels.split(','))
+    #set($discard = $lowerCaseLabelList.add($label.toLowerCase()))
+  #end
+  #set($params = {
+    'className': 'XWiki.TagClass',
+    'propName': 'tags',
+    'labelsList': $lowerCaseLabelList
+  })
+  #if("$!spaces" != '')
+    #set ($statement = $statement + ' and (')
+    #foreach($space in $spaces.split('(?&lt;!\\\\), '))
+      #if($foreach.index &gt; 0)
+        #set($statement = $statement + ' or ')
+      #end
+      #set($statement = $statement + "doc.space like :space$foreach.index")
+      #set($discard = $params.put("space$foreach.index", $space.replaceAll('([%_!])', '!$1').concat('%')))
+    #end
+    #set($statement = $statement + ')')
+  #end
+  #set ($statement = $statement + ' order by doc.date desc')
+  #set($query = $services.query.hql($statement))
+  #set($discard = $query.bindValues($params))
+  #if("$!maxResults" != '')
+   #set($discard = $query.setLimit($mathtool.toNumber($maxResults)).addFilter('currentlanguage'))
+  #end
+  #set($results = $query.execute())
+  ## Table display
+  |=$services.localization.render('titlefield')|=$services.localization.render('creator')|=$services.localization.render('contentReportTable.header.modified')
+  #foreach($result in $results)
+    |[[$result.get(1)&gt;&gt;$result.get(0)]]|{{html clean="false"}}$xwiki.getUserName($result.get(2), true){{/html}}|$datetool.format('MMM dd, yyyy', $result.get(3))
+  #end
 #end
-#set ($statement = $statement + ' order by doc.date desc')
-#set($query = $services.query.hql($statement))
-#set($discard = $query.bindValues($params))
-#if("$!maxResults" != '')
- #set($discard = $query.setLimit($mathtool.toNumber($maxResults)).addFilter('currentlanguage'))
-#end
-#set($results = $query.execute())
-## Table display
-|=$services.localization.render('titlefield')|=$services.localization.render('creator')|=$services.localization.render('contentReportTable.header.modified')
-#foreach($result in $results)
-  |[[$result.get(1)&gt;&gt;$result.get(0)]]|{{html clean="false"}}$xwiki.getUserName($result.get(2), true){{/html}}|$datetool.format('MMM dd, yyyy', $result.get(3))
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
 {{/velocity}}</code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
@@ -281,8 +281,19 @@ The result is the following:
     <property>
       <code>{{include reference="Confluence.Macros.DiagramMacros" /}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-#displayConfluenceDiagram()
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #displayConfluenceDiagram()
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Excerpt.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Excerpt.xml
@@ -270,20 +270,37 @@ My hidden content.
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-## BLOCK / INLINE
-#set($outputType = $wikimacro.parameters.get('atlassian-macro-output-type'))
-#set($hidden = $wikimacro.parameters.get('hidden'))
-#set($displayAsBlock = "$!outputType" != '' &amp;&amp; $outputType.toLowerCase() == 'block')
-#if("$!hidden" == 'true')
-  (% class="hidden" %)
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  ## BLOCK / INLINE
+  #set($outputType = $wikimacro.parameters.get('atlassian-macro-output-type'))
+  #set($hidden = $wikimacro.parameters.get('hidden'))
+  #set($displayAsBlock = "$!outputType" != '' &amp;&amp; $outputType.toLowerCase() == 'block')
+  #if("$!hidden" == 'true')
+    (% class="hidden" %)
+  #end
+  #if($displayAsBlock)
+    (((
+  #end
+    {{wikimacrocontent /}}
+  #if($displayAsBlock)
+    )))
+  #end
 #end
-#if($displayAsBlock)
-  (((
-#end
-  {{wikimacrocontent /}}
-#if($displayAsBlock)
-  )))
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
 {{/velocity}}</code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -409,42 +409,58 @@ Hello 👀
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-$xwiki.ssx.use('Confluence.Macros.Expand')
-#if (!$expandMacroColllapseId)
-  #set ($expandMacroColllapseId = 0)
-#else
-  #set ($expandMacroColllapseId = $expandMacroColllapseId + 1)
-#end
-#set ($opened = $xcontext.action == 'edit')
-#set ($accordionId = "accordion-$escapetool.xml($expandMacroColllapseId)")
-#set ($toggleId = "toggle-$expandMacroColllapseId")
-#set ($expandId = "collapse-$expandMacroColllapseId")
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  $xwiki.ssx.use('Confluence.Macros.Expand')
+  #if (!$expandMacroColllapseId)
+    #set ($expandMacroColllapseId = 0)
+  #else
+    #set ($expandMacroColllapseId = $expandMacroColllapseId + 1)
+  #end
+  #set ($opened = $xcontext.action == 'edit')
+  #set ($accordionId = "accordion-$escapetool.xml($expandMacroColllapseId)")
+  #set ($toggleId = "toggle-$expandMacroColllapseId")
+  #set ($expandId = "collapse-$expandMacroColllapseId")
 
-{{html clean="false" wiki="true"}}
-&lt;div class="panel-group confluence-expand-macro" id="${accordionId}" role="tablist"&gt;
-  &lt;div class="panel panel-default"&gt;
-    &lt;div class="panel-heading" role="tab" id="${toggleId}"&gt;
-      &lt;h4 class="panel-title"&gt;
-        &lt;a
-          role="button"
-          data-toggle="collapse"
-          data-parent="#${accordionId}"
-          href="#${expandId}"
-          #if($opened)aria-expanded="true"#end
-          aria-controls="${expandId}"
-        &gt;&lt;span class="glyphicon glyphicon-menu-right" aria-hidden="true"&gt;&lt;/span&gt;{{wikimacroparameter name="title" /}}&lt;/a&gt;
-      &lt;/h4&gt;
-    &lt;/div&gt;
-    &lt;div id="${expandId}" class="panel-collapse collapse #if($opened)in#end" role="tabpanel" aria-labelledby="${toggleId}"&gt;
-      &lt;div class="panel-body"&gt;
-        {{wikimacrocontent /}}
+  {{html clean="false" wiki="true"}}
+  &lt;div class="panel-group confluence-expand-macro" id="${accordionId}" role="tablist"&gt;
+    &lt;div class="panel panel-default"&gt;
+      &lt;div class="panel-heading" role="tab" id="${toggleId}"&gt;
+        &lt;h4 class="panel-title"&gt;
+          &lt;a
+            role="button"
+            data-toggle="collapse"
+            data-parent="#${accordionId}"
+            href="#${expandId}"
+            #if($opened)aria-expanded="true"#end
+            aria-controls="${expandId}"
+          &gt;&lt;span class="glyphicon glyphicon-menu-right" aria-hidden="true"&gt;&lt;/span&gt;{{wikimacroparameter name="title" /}}&lt;/a&gt;
+        &lt;/h4&gt;
+      &lt;/div&gt;
+      &lt;div id="${expandId}" class="panel-collapse collapse #if($opened)in#end" role="tabpanel" aria-labelledby="${toggleId}"&gt;
+        &lt;div class="panel-body"&gt;
+          {{wikimacrocontent /}}
+        &lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;
-  &lt;/div&gt;
- &lt;/div&gt;
-{{/html}}
+   &lt;/div&gt;
+  {{/html}}
+#end
+{{/velocity}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
@@ -281,8 +281,19 @@ The result is the following:
     <property>
       <code>{{include reference="Confluence.Macros.DiagramMacros" /}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-#displayConfluenceDiagram()
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #displayConfluenceDiagram()
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Layout.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Layout.xml
@@ -388,15 +388,32 @@ On the other hand, we denounce with righteous indignation.
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-(% class="macro-layout" %)(((
-  ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-  #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-    {{wikimacrocontent /}}
-  #else
-    $!xcontext.macro.content
-  #end
-)))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  (% class="macro-layout" %)(((
+    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+      {{wikimacrocontent /}}
+    #else
+      $!xcontext.macro.content
+    #end
+  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/LayoutCell.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/LayoutCell.xml
@@ -240,15 +240,32 @@ On the other hand, we denounce with righteous indignation
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-(% class="macro-layout-cell" %)(((
-  ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-  #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-    {{wikimacrocontent /}}
-  #else
-    $!xcontext.macro.content
-  #end
-)))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  (% class="macro-layout-cell" %)(((
+    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+      {{wikimacrocontent /}}
+    #else
+      $!xcontext.macro.content
+    #end
+  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/LayoutSection.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/LayoutSection.xml
@@ -423,17 +423,34 @@ On the other hand, we denounce with righteous indignation.
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($discard = $xwiki.ssx.use('Confluence.Macros.LayoutSection'))
-#set ($cssLayoutClass = $xcontext.macro.params.get('ac:type'))
-(% class="macro-layout-section $cssLayoutClass" %)(((
-  ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-  #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-    {{wikimacrocontent /}}
-  #else
-    $!xcontext.macro.content
-  #end
-)))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('Confluence.Macros.LayoutSection'))
+  #set ($cssLayoutClass = $xcontext.macro.params.get('ac:type'))
+  (% class="macro-layout-section $cssLayoutClass" %)(((
+    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+      {{wikimacrocontent /}}
+    #else
+      $!xcontext.macro.content
+    #end
+  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Mockup.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Mockup.xml
@@ -271,7 +271,8 @@ Filename number 1. has priority, so in case both files are attached to the curre
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
   ## Filename format : &lt;balsamiq/mockup&gt;_&lt;$Name/$initialResourceID&gt;[/_$initialBranchID].png
   #set($attachmentNamePrefix = 'balsamiq')
   #set($attachmentNameSuffix = '')
@@ -292,6 +293,22 @@ Filename number 1. has priority, so in case both files are attached to the curre
   #if($attachment)
     [[image:${attachmentName}]]
   #end
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Multimedia.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Multimedia.xml
@@ -283,19 +283,36 @@ The result is the following :
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set($attachment = $wikimacro.parameters.get('att--filename'))
-#if(!$attachment)
-  #set($attachment = $wikimacro.parameters.get('name'))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set($attachment = $wikimacro.parameters.get('att--filename'))
+  #if(!$attachment)
+    #set($attachment = $wikimacro.parameters.get('name'))
+  #end
+  #set($page = $wikimacro.parameters.get('page'))
+  #set($width = $wikimacro.parameters.get('width'))
+  #set($height = $wikimacro.parameters.get('height'))
+  #set($autostart = "$!wikimacro.parameters.get('autostart').toLowerCase()" == 'true')
+  #if("$!page" != '')
+    #set($attachment = "${page}@${attachment}")
+  #end
+  {{jwplayer attachment="${attachment}" width="$!{width}" height="$!{height}" autostart="$!{autostart}" /}}
 #end
-#set($page = $wikimacro.parameters.get('page'))
-#set($width = $wikimacro.parameters.get('width'))
-#set($height = $wikimacro.parameters.get('height'))
-#set($autostart = "$!wikimacro.parameters.get('autostart').toLowerCase()" == 'true')
-#if("$!page" != '')
-  #set($attachment = "${page}@${attachment}")
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
-{{jwplayer attachment="${attachment}" width="$!{width}" height="$!{height}" autostart="$!{autostart}" /}}
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Note.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Note.xml
@@ -251,7 +251,8 @@ This is my note with title.
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
   {{warning}}
     #if("$!wikimacro.parameters.title" != "")
     **{{wikimacroparameter name="title" /}}**
@@ -259,6 +260,22 @@ This is my note with title.
     #end
     {{wikimacrocontent /}}
   {{/warning}}
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
@@ -399,7 +399,8 @@ class Simple{
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
   #set($discard = $xwiki.ssx.use('Confluence.Macros.PasteCode'))
   ## Macro parameters
   #set($language = $wikimacro.parameters.get('language'))
@@ -415,6 +416,22 @@ class Simple{
       $wikimacro.content
     {{/code}}
   )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdated.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdated.xml
@@ -963,33 +963,48 @@ require(['jquery'], $ =&gt; {
   #set ($return = $NULL)
   #setVariable("$return" $options)
 #end
+
+#macro (executeMacro)
+  ## -----------------------------------------------------------------
+  ## -----------------------------------------------------------------
+  ## -----------------------------------------------------------------
+  ## Fetch results
+  ## -----------------------------------------------------------------
+  $xwiki.ssx.use('xwiki:Confluence.Macros.RecentlyUpdated')
+  $xwiki.jsx.use('xwiki:Confluence.Macros.RecentlyUpdated')
+  {{html clean="false"}}
+    #initOptionsFromParameters($options)
+    #fetchResults($options, $results)
+    #set ($confluenceWidth = $escapetool.xml($wikimacro.parameters.width))
+    #set ($widthStyle = "style='--width: $confluenceWidth'")
+    &lt;section class="recently-updated-macro" $widthStyle&gt;
+      #if ("$wikimacro.parameters.hideHeading" != "true")
+        &lt;h2&gt;$escapetool.xml($services.localization.render('recentlyUpdatedMacro.title'))&lt;/h2&gt;
+      #end
+      &lt;ul class="results theme-${options.theme}"&gt;
+        #displayResults($results $options)
+      &lt;/ul&gt;
+      &lt;button class="btn btn-link show-more"&gt;
+        Show more
+      &lt;/button&gt;
+    &lt;/section&gt;
+  {{/html}}
+#end
 {{/velocity}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-## -----------------------------------------------------------------
-## -----------------------------------------------------------------
-## -----------------------------------------------------------------
-## Fetch results
-## -----------------------------------------------------------------
-$xwiki.ssx.use('xwiki:Confluence.Macros.RecentlyUpdated')
-$xwiki.jsx.use('xwiki:Confluence.Macros.RecentlyUpdated')
-{{html clean="false"}}
-  #initOptionsFromParameters($options)
-  #fetchResults($options, $results)
-  #set ($confluenceWidth = $escapetool.xml($wikimacro.parameters.width))
-  #set ($widthStyle = "style='--width: $confluenceWidth'")
-  &lt;section class="recently-updated-macro" $widthStyle&gt;
-    #if ("$wikimacro.parameters.hideHeading" != "true")
-      &lt;h2&gt;$escapetool.xml($services.localization.render('recentlyUpdatedMacro.title'))&lt;/h2&gt;
-    #end
-    &lt;ul class="results theme-${options.theme}"&gt;
-      #displayResults($results $options)
-    &lt;/ul&gt;
-    &lt;button class="btn btn-link show-more"&gt;
-      Show more
-    &lt;/button&gt;
-  &lt;/section&gt;
-{{/html}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}
 </code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
@@ -454,22 +454,39 @@ Content in the column 4
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($discard = $xwiki.ssx.use('Confluence.Macros.Section'))
-#set ($discard = $xwiki.jsx.use('Confluence.Macros.Section'))
-#set ($hasBorder = "$!xcontext.macro.params.border")
-#set ($extraClass = '')
-#if ($hasBorder == 'true')
-  #set ($extraClass = 'hasBorder')
-#end
-(% class="macro-section $extraClass" %)(((
-  ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-  #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-    {{wikimacrocontent /}}
-  #else
-    $!xcontext.macro.content
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('Confluence.Macros.Section'))
+  #set ($discard = $xwiki.jsx.use('Confluence.Macros.Section'))
+  #set ($hasBorder = "$!xcontext.macro.params.border")
+  #set ($extraClass = '')
+  #if ($hasBorder == 'true')
+    #set ($extraClass = 'hasBorder')
   #end
-)))
+  (% class="macro-section $extraClass" %)(((
+    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+      {{wikimacrocontent /}}
+    #else
+      $!xcontext.macro.content
+    #end
+  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Tip.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Tip.xml
@@ -251,7 +251,8 @@ This is my tip with a title.
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
   {{success}}
     #if("$!wikimacro.parameters.title" != "")
       **$services.rendering.escape($wikimacro.parameters.title, $services.rendering.resolveSyntax($xwiki.getCurrentContentSyntaxId()))**
@@ -259,6 +260,22 @@ This is my tip with a title.
     #end
     $!wikimacro.content
   {{/success}}
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -252,22 +252,39 @@
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set($hasPDFViewer = $xwiki.exists("XWiki.PDFViewerMacro"))
-#set($officeExtensions = [ 'ppt', 'pptx', 'odp', 'doc', 'docx', 'odt', 'xls', 'xlsx', 'ods' ])
-#set($filename = $xcontext.macro.params.get('att--filename'))
-#if(!$filename)
-  #set($filename = $xcontext.macro.params.get('name'))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set($hasPDFViewer = $xwiki.exists("XWiki.PDFViewerMacro"))
+  #set($officeExtensions = [ 'ppt', 'pptx', 'odp', 'doc', 'docx', 'odt', 'xls', 'xlsx', 'ods' ])
+  #set($filename = $xcontext.macro.params.get('att--filename'))
+  #if(!$filename)
+    #set($filename = $xcontext.macro.params.get('name'))
+  #end
+  #set($extension = $filename.substring($mathtool.add($filename.lastIndexOf('.'), 1)).toLowerCase())
+  #if($extension == 'pdf' &amp;&amp; $hasPDFViewer)
+
+    {{pdfviewer file="${filename}" /}}
+  #elseif($officeExtensions.contains($extension))
+
+    {{office reference="attach:${filename}" /}}
+  #elseif($doc.getAttachment($filename))
+    [[attach:${filename}]]
+  #end
 #end
-#set($extension = $filename.substring($mathtool.add($filename.lastIndexOf('.'), 1)).toLowerCase())
-#if($extension == 'pdf' &amp;&amp; $hasPDFViewer)
+{{/velocity}}
 
-  {{pdfviewer file="${filename}" /}}
-#elseif($officeExtensions.contains($extension))
+{{include reference="Licenses.Code.VelocityMacros"/}}
 
-  {{office reference="attach:${filename}" /}}
-#elseif($doc.getAttachment($filename))
-  [[attach:${filename}]]
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
 {{/velocity}}</code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewdoc.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewdoc.xml
@@ -244,12 +244,29 @@
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($filename = $xcontext.macro.params.get('att--filename'))
-#if (!$filename)
-  #set ($filename = $xcontext.macro.params.get('name'))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($filename = $xcontext.macro.params.get('att--filename'))
+  #if (!$filename)
+    #set ($filename = $xcontext.macro.params.get('name'))
+  #end
+  {{office reference="$filename" /}}
 #end
-{{office reference="$filename" /}}
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewppt.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewppt.xml
@@ -244,12 +244,29 @@
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($filename = $xcontext.macro.params.get('att--filename'))
-#if (!$filename)
-  #set ($filename = $xcontext.macro.params.get('name'))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($filename = $xcontext.macro.params.get('att--filename'))
+  #if (!$filename)
+    #set ($filename = $xcontext.macro.params.get('name'))
+  #end
+  {{office reference="$filename" /}}
 #end
-{{office reference="$filename" /}}
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewxls.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewxls.xml
@@ -244,12 +244,29 @@
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($filename = $xcontext.macro.params.get('att--filename'))
-#if (!$filename)
-  #set ($filename = $xcontext.macro.params.get('name'))
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($filename = $xcontext.macro.params.get('att--filename'))
+  #if (!$filename)
+    #set ($filename = $xcontext.macro.params.get('name'))
+  #end
+  {{office reference="$filename" /}}
 #end
-{{office reference="$filename" /}}
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
@@ -300,44 +300,58 @@ $services.localization.render('rendering.macro.button.description')
     #fff
   #end
 #end
+#macro (executeMacro)
+  ## Retrieve macro parameters
+  #set ($label = $escapetool.xml($wikimacro.parameters.label))
+  #set ($url = $escapetool.xml($wikimacro.parameters.url))
+  #set ($color = $wikimacro.parameters.color)
+  #set ($width = $escapetool.xml($wikimacro.parameters.width))
+  #set ($newTab = $escapetool.xml($wikimacro.parameters.newTab))
+  #set ($icon = $escapetool.xml($xcontext.macro.params.icon))
+  ## Resolve the url as a Wiki Document if it exists, else assume it is an external link
+  #if ($xwiki.exists($url))
+    #set ($url = $xwiki.getDocument($url).getURL())
+  #end
+  ## The color will be a java.awt.Color object
+  ## Transform it into an array of Integers for better malleability: [x, y, z]
+  #if ($color)
+    #set ($colors = [$color.Red, $color.Green, $color.Blue])
+  #else
+    #set ($colors = [255, 255, 255])
+  #end
+  #set ($darkenedColors = [])
+  #darken($colors, $darkenedColors)
+  {{html clean=false}}
+  &lt;a href="$url" #if($newTab == 'true')target="_blank"#end&gt;
+    &lt;button
+      style="
+        background-color: #toCssRGB($colors);
+        border-color: #toCssRGB($darkenedColors);
+        color: #fontColor($colors);
+        width: $!width;
+      "
+      class="btn"&gt;
+      $!services.icon.renderHTML($!icon)
+      $label
+    &lt;/button&gt;
+  &lt;/a&gt;
+  {{/html}}
+#end
 {{/velocity}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-## Retrieve macro parameters
-#set ($label = $escapetool.xml($wikimacro.parameters.label))
-#set ($url = $escapetool.xml($wikimacro.parameters.url))
-#set ($color = $wikimacro.parameters.color)
-#set ($width = $escapetool.xml($wikimacro.parameters.width))
-#set ($newTab = $escapetool.xml($wikimacro.parameters.newTab))
-#set ($icon = $escapetool.xml($xcontext.macro.params.icon))
-## Resolve the url as a Wiki Document if it exists, else assume it is an external link
-#if ($xwiki.exists($url))
-  #set ($url = $xwiki.getDocument($url).getURL())
-#end
-## The color will be a java.awt.Color object
-## Transform it into an array of Integers for better malleability: [x, y, z]
-#if ($color)
-  #set ($colors = [$color.Red, $color.Green, $color.Blue])
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
 #else
-  #set ($colors = [255, 255, 255])
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
-#set ($darkenedColors = [])
-#darken($colors, $darkenedColors)
-{{html clean=false}}
-&lt;a href="$url" #if($newTab == 'true')target="_blank"#end&gt;
-  &lt;button
-    style="
-      background-color: #toCssRGB($colors);
-      border-color: #toCssRGB($darkenedColors);
-      color: #fontColor($colors);
-      width: $!width;
-    "
-    class="btn"&gt;
-    $!services.icon.renderHTML($!icon)
-    $label
-  &lt;/button&gt;
-&lt;/a&gt;
-{{/html}}
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/MicrosoftStream.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/MicrosoftStream.xml
@@ -450,35 +450,50 @@ $xwiki.currentContentSyntaxId)|No|false
       + $datetool.getValue('SECOND', $dateObj))
   #end
 #end
+
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('XWiki.Macros.MicrosoftStream'))
+  #getAlignmentClass($stringtool.lowerCase($xcontext.macro.params.alignment) $alignmentClass)
+  #getBaseURLAndQueryParams($xcontext.macro.params.url $baseURL $queryParams)
+  ## Update the query params, if needed, since macro parameters have priority over the parameters extracted from URL.
+  #set ($autoplay = $xcontext.macro.params.autoplay)
+  #if ($autoplay)
+    #set ($discard = $queryParams.put('autoplay', $autoplay))
+  #end
+  #set ($showinfo = $xcontext.macro.params.showinfo)
+  #if ($showinfo)
+    #set ($discard = $queryParams.put('showinfo', $showinfo))
+  #end
+  #if ($xcontext.macro.params.start)
+    #getStartAsSeconds($xcontext.macro.params.start $startSeconds)
+    #if ($queryParams.st != $startSeconds)
+      #set ($discard = $queryParams.put('st', $startSeconds))
+    #end
+  #end
+  #set ($videoURL = $baseURL + '?' + $escapetool.url($queryParams))
+  {{html clean=false}}
+    &lt;p class="msStreamMacro $!escapetool.xml($alignmentClass)"&gt;
+      &lt;iframe width="$escapetool.xml($xcontext.macro.params.width)"
+        height="$escapetool.xml($xcontext.macro.params.height)" src="$escapetool.xml($videoURL)" allowfullscreen&gt;
+      &lt;/iframe&gt;
+    &lt;/p&gt;
+  {{/html}}
+#end
 {{/velocity}}
 
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
 {{velocity}}
-#set ($discard = $xwiki.ssx.use('XWiki.Macros.MicrosoftStream'))
-#getAlignmentClass($stringtool.lowerCase($xcontext.macro.params.alignment) $alignmentClass)
-#getBaseURLAndQueryParams($xcontext.macro.params.url $baseURL $queryParams)
-## Update the query params, if needed, since macro parameters have priority over the parameters extracted from URL.
-#set ($autoplay = $xcontext.macro.params.autoplay)
-#if ($autoplay)
-  #set ($discard = $queryParams.put('autoplay', $autoplay))
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
-#set ($showinfo = $xcontext.macro.params.showinfo)
-#if ($showinfo)
-  #set ($discard = $queryParams.put('showinfo', $showinfo))
-#end
-#if ($xcontext.macro.params.start)
-  #getStartAsSeconds($xcontext.macro.params.start $startSeconds)
-  #if ($queryParams.st != $startSeconds)
-    #set ($discard = $queryParams.put('st', $startSeconds))
-  #end
-#end
-#set ($videoURL = $baseURL + '?' + $escapetool.url($queryParams))
-{{html clean=false}}
-  &lt;p class="msStreamMacro $!escapetool.xml($alignmentClass)"&gt;
-    &lt;iframe width="$escapetool.xml($xcontext.macro.params.width)"
-      height="$escapetool.xml($xcontext.macro.params.height)" src="$escapetool.xml($videoURL)" allowfullscreen&gt;
-    &lt;/iframe&gt;
-  &lt;/p&gt;
-{{/html}}
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
@@ -421,87 +421,104 @@ This macro supports all Atlassian Confluence parameters as of version 7.9.</cont
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set ($discard = $xwiki.ssx.use('XWiki.Macros.Panel'))
-#set ($panelTitle = "$!xcontext.macro.params.title")
-#set ($borderColor = "$!xcontext.macro.params.borderColor")
-#set ($borderWidth = "$!xcontext.macro.params.borderWidth")
-#set ($borderStyle = "$!xcontext.macro.params.borderStyle")
-#set ($borderRadius = "$!xcontext.macro.params.borderRadius")
-#set ($bgColor = "$!xcontext.macro.params.bgColor")
-#set ($contentTextColor = "$!xcontext.macro.params.contentTextColor")
-#set ($titleBGColor = "$!xcontext.macro.params.titleBGColor")
-#set ($titleColor = "$!xcontext.macro.params.titleColor")
-#set ($width = "$!xcontext.macro.params.width")
-#set ($classes = "$!xcontext.macro.params.classes")
-## Panel border style
-#set ($panelBorderStyle = '')
-#if ($width != '')
-  #set ($panelBorderStyle = "${panelBorderStyle}width: $width; ")
-#end
-#if ($borderStyle != '')
-  #set ($panelBorderStyle = "${panelBorderStyle}border: $borderStyle; ")
-#end
-#if ($borderColor != '')
-  #set ($panelBorderStyle = "${panelBorderStyle}border-color: $borderColor; ")
-#end
-#if ($borderWidth != '')
-  #set ($panelBorderStyle = "${panelBorderStyle}border-width: ${borderWidth}px; ")
-#end
-#if ($borderRadius != '')
-  #set ($panelBorderStyle = "${panelBorderStyle}border-radius: $borderRadius; ")
-#end
-## Panel title style.
-#set ($panelTitleStyle = '')
-#if ($titleBGColor != '')
-  #set ($panelTitleStyle = "${panelTitleStyle}background-color: $titleBGColor; ")
-#end
-#if ($titleColor != '')
-  #set ($panelTitleStyle = "${panelTitleStyle}color: $titleColor; ")
-#end
-## Panel content style.
-#set ($panelContentStyle = '')
-#if ($bgColor != '')
-  #set ($panelContentStyle = "${panelContentStyle}background-color: $bgColor; ")
-#end
-#if ($contentTextColor != '')
-  #set ($panelContentStyle = "${panelContentStyle}color: $contentTextColor; ")
-#end
-#*
-  If there is a bootstrap class provided, the panel needs an inner container in order to properly handle the borders.
-  Wraper structure with bootstrap class:
-    &lt;div class="macro-panel col-sm-12"&gt;&lt;div class="macro-border"&gt;TITLE and CONTENT&lt;/div&gt;&lt;/div&gt;
-  Wraper structure without bootstrap class:
-    &lt;div class="macro-panel macro-border"&gt;TITLE and CONTENT&lt;/div&gt;
-*#
-#set ($macroBorderClass = 'macro-border')
-#if ("$!classes" != '')
-  (% class="macro-panel $classes" %)(((
-#else
-  #set ($macroBorderClass = "$macroBorderClass macro-panel")
-#end
-(% class="$macroBorderClass" style="$panelBorderStyle" %)(((
-  #if( $panelTitle != '')
-    (% class="macro-panel-title" style="$panelTitleStyle"%)(((
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('XWiki.Macros.Panel'))
+  #set ($panelTitle = "$!xcontext.macro.params.title")
+  #set ($borderColor = "$!xcontext.macro.params.borderColor")
+  #set ($borderWidth = "$!xcontext.macro.params.borderWidth")
+  #set ($borderStyle = "$!xcontext.macro.params.borderStyle")
+  #set ($borderRadius = "$!xcontext.macro.params.borderRadius")
+  #set ($bgColor = "$!xcontext.macro.params.bgColor")
+  #set ($contentTextColor = "$!xcontext.macro.params.contentTextColor")
+  #set ($titleBGColor = "$!xcontext.macro.params.titleBGColor")
+  #set ($titleColor = "$!xcontext.macro.params.titleColor")
+  #set ($width = "$!xcontext.macro.params.width")
+  #set ($classes = "$!xcontext.macro.params.classes")
+  ## Panel border style
+  #set ($panelBorderStyle = '')
+  #if ($width != '')
+    #set ($panelBorderStyle = "${panelBorderStyle}width: $width; ")
+  #end
+  #if ($borderStyle != '')
+    #set ($panelBorderStyle = "${panelBorderStyle}border: $borderStyle; ")
+  #end
+  #if ($borderColor != '')
+    #set ($panelBorderStyle = "${panelBorderStyle}border-color: $borderColor; ")
+  #end
+  #if ($borderWidth != '')
+    #set ($panelBorderStyle = "${panelBorderStyle}border-width: ${borderWidth}px; ")
+  #end
+  #if ($borderRadius != '')
+    #set ($panelBorderStyle = "${panelBorderStyle}border-radius: $borderRadius; ")
+  #end
+  ## Panel title style.
+  #set ($panelTitleStyle = '')
+  #if ($titleBGColor != '')
+    #set ($panelTitleStyle = "${panelTitleStyle}background-color: $titleBGColor; ")
+  #end
+  #if ($titleColor != '')
+    #set ($panelTitleStyle = "${panelTitleStyle}color: $titleColor; ")
+  #end
+  ## Panel content style.
+  #set ($panelContentStyle = '')
+  #if ($bgColor != '')
+    #set ($panelContentStyle = "${panelContentStyle}background-color: $bgColor; ")
+  #end
+  #if ($contentTextColor != '')
+    #set ($panelContentStyle = "${panelContentStyle}color: $contentTextColor; ")
+  #end
+  #*
+    If there is a bootstrap class provided, the panel needs an inner container in order to properly handle the borders.
+    Wraper structure with bootstrap class:
+      &lt;div class="macro-panel col-sm-12"&gt;&lt;div class="macro-border"&gt;TITLE and CONTENT&lt;/div&gt;&lt;/div&gt;
+    Wraper structure without bootstrap class:
+      &lt;div class="macro-panel macro-border"&gt;TITLE and CONTENT&lt;/div&gt;
+  *#
+  #set ($macroBorderClass = 'macro-border')
+  #if ("$!classes" != '')
+    (% class="macro-panel $classes" %)(((
+  #else
+    #set ($macroBorderClass = "$macroBorderClass macro-panel")
+  #end
+  (% class="$macroBorderClass" style="$panelBorderStyle" %)(((
+    #if( $panelTitle != '')
+      (% class="macro-panel-title" style="$panelTitleStyle"%)(((
+        ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
+        #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacroparameter')))
+          {{wikimacroparameter name="title" /}}
+        #else
+          $panelTitle
+        #end
+      )))
+    #end
+    (% class="macro-panel-content" style="$panelContentStyle"%)(((
       ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-      #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacroparameter')))
-        {{wikimacroparameter name="title" /}}
+      #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
+        {{wikimacrocontent /}}
       #else
-        $panelTitle
+        $!xcontext.macro.content
       #end
     )))
+  )))
+  #if ("$!classes" != '')
+    )))
   #end
-  (% class="macro-panel-content" style="$panelContentStyle"%)(((
-    ## Since 11.5 the content of the macro can be edited in WYSIWYG editor.
-    #if ($services.rendering.getMacroDescriptor($services.rendering.resolveMacroId('wikimacrocontent')))
-      {{wikimacrocontent /}}
-    #else
-      $!xcontext.macro.content
-    #end
-  )))
-)))
-#if ("$!classes" != '')
-  )))
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
 {{/velocity}}</code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Status.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Status.xml
@@ -358,25 +358,42 @@ Add a new status macro.{{status title="Improvement" colour="Green" subtle="true"
       </visibility>
     </class>
     <property>
-      <code>{{velocity}}
-#set ($discard = $xwiki.ssx.use('XWiki.Macros.Status'))
-#set ($color = $xcontext.macro.params.colour)
-#if (!$color)
-  #set ($color = 'Grey')
+      <code>{{velocity output="false"}}
+#macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('XWiki.Macros.Status'))
+  #set ($color = $xcontext.macro.params.colour)
+  #if (!$color)
+    #set ($color = 'Grey')
+  #end
+  #set ($title = $xcontext.macro.params.title)
+  #if (!$title)
+    #set ($title = $color)
+  #end
+  #set ($statusCssClass = "${color.toLowerCase()}Status statusBox")
+  #set ($subtle = $xcontext.macro.params.subtle)
+  #set ($subtleCssClass = 'subtle')
+  #if ($subtle == 'true')
+    #set ($statusCssClass = "$statusCssClass subtle")
+  #end
+  {{html}}
+    &lt;span class="$statusCssClass" title="$title"&gt;$title&lt;/span&gt;
+  {{/html}}
 #end
-#set ($title = $xcontext.macro.params.title)
-#if (!$title)
-  #set ($title = $color)
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
 #end
-#set ($statusCssClass = "${color.toLowerCase()}Status statusBox")
-#set ($subtle = $xcontext.macro.params.subtle)
-#set ($subtleCssClass = 'subtle')
-#if ($subtle == 'true')
-  #set ($statusCssClass = "$statusCssClass subtle")
-#end
-{{html}}
-  &lt;span class="$statusCssClass" title="$title"&gt;$title&lt;/span&gt;
-{{/html}}
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
@@ -689,10 +689,7 @@
       <async_enabled>0</async_enabled>
     </property>
     <property>
-      <code>{{velocity}}
-#set($discard = $xwiki.ssx.use('xwiki:XWiki.Macros.Team'))
-#set($discard = $xwiki.jsx.use('xwiki:XWiki.Macros.Team'))
-#set($pictureList = {})
+      <code>{{velocity output="false"}}
 #macro(avatarInitials $name $size $letterAvatarBgColor $letterAvatarFontColor)
   #set($escapedSize = $escapetool.xml($size))
   #set($escapedLetterAvatarFontColor = $escapetool.xml($letterAvatarFontColor))
@@ -739,148 +736,168 @@
     &lt;/a&gt;
   &lt;/li&gt;
 #end
-#set($tag = $wikimacro.parameters.tag)
-#set($size = $wikimacro.parameters.size)
-#set($scope = $wikimacro.parameters.scope)
-#set($letterAvatarBgColor = $wikimacro.parameters.letterAvatarBgColor)
-#set($letterAvatarFontColor = $wikimacro.parameters.letterAvatarFontColor)
-#set($requireExternalAuth = $wikimacro.parameters.requireExternalAuth)
-#set($showUsernames = $wikimacro.parameters.showUsernames)
-#set($disableTools = $wikimacro.parameters.disableTools)
-#set($disableLetterAvatars = $wikimacro.parameters.disableLetterAvatars)
-#set($limit = $wikimacro.parameters.limit)
-#if("$!size" == "")
-  #set($size = 60)
-#end
-#if("$!scope" == "")
-  #set($scope = "auto")
-#end
-#if($scope == "auto")
-  #if($xcontext.database != $xcontext.mainWikiName &amp;&amp; "$!services.wiki" != '')
-    #set ($wikiUserScope = $services.wiki.user.getUserScope($services.wiki.currentWikiId))
-    #if($wikiUserScope == 'GLOBAL_ONLY')
-      #set($scope = 'global')
-    #elseif($wikiUserScope == 'LOCAL_AND_GLOBAL')
-      #set($scope = 'both')
-    #else
-      #set($scope = 'local')
-    #end
-  #else
-    #set($scope = 'global')
-  #end
-#end
-#if($scope == "both" &amp;&amp; $xcontext.database == $xcontext.mainWikiName)
-  #set($scope = "global")
-#end
-#if("$!letterAvatarBgColor" == "")
-  #set($letterAvatarBgColor = "#0A6")
-#end
-#if("$!letterAvatarFontColor" == "")
-  #set($letterAvatarFontColor = "white")
-#end
-#if("$!requireExternalAuth" == "" || "$!requireExternalAuth" == "false" || "$!requireExternalAuth" == "0")
-  #set($requireExternalAuth = false)
-#end
-#if("$!showUsernames" == "" || "$!showUsernames" == "false" || "$!showUsernames" == "0")
-  #set($showUsernames = false)
-#end
-#if("$!disableTools" == "" || "$!disableTools" == "false" || "$!disableTools" == "0")
-  #set($disableTools = false)
-#end
-#if("$!disableLetterAvatars" == "" || "$!disableLetterAvatars" == "false" || "$!disableLetterAvatars" == "0")
-  #set($disableLetterAvatars = false)
-#end
-#if("$!limit" == "")
-  #set($limit = 100)
-#end
-#if(!$tag || $tag == "")
-  #set($tagselect = "")
-  #set($tagwhere = "")
-#else
-  #set($tagselect = ",
-      BaseObject as obj3,
-      DBStringListProperty as tagprop
-    JOIN
-      tagprop.list list
-  ")
-  #set($tagwhere = " and
-    doc.fullName = obj3.name and
-    obj3.className = 'XWiki.TagClass' and
-    obj3.id = tagprop.id.id and
-    tagprop.id.name = 'tags' and
-    list = '$tag'
-  ")
-#end
-#set($hql = ",
-    BaseObject as obj
-    #if($requireExternalAuth), BaseObject as obj2 #end,
-    IntegerProperty as prop
-    $tagselect
-  WHERE
-    doc.fullName = obj.name and
-    obj.className = 'XWiki.XWikiUsers'
-    #if($requireExternalAuth) and
-      doc.fullName = obj2.name and (
-        obj2.className = 'XWiki.LDAPProfileClass' or
-        obj2.className = 'XWiki.OIDC.UserClass'
-      )
-    #end and
-    obj.id = prop.id.id and
-    prop.id.name = 'active' and
-    prop.value = 1
-    $tagwhere
-  ORDER BY doc.name
-")
-#macro(addUsersFromWiki $list $wiki $limit)
+#macro (addUsersFromWiki $list $wiki $limit)
   #set($l = $services.query.hql($hql).setLimit($limit).setWiki($wiki).execute())
   #foreach($username in $l)
     #set($discard = $list.add("$wiki:$username"))
   #end
 #end
-#set($list = [])
-#if ($scope == "global")
-  #addUsersFromWiki($list $xcontext.mainWikiName $limit)
-#elseif ($scope == "local")
-  #addUsersFromWiki($list $services.wiki.currentWikiId $limit)
-#elseif ($scope == "both")
-  #addUsersFromWiki($list $services.wiki.currentWikiId $limit)
-  #if($list.size() &lt; $limit)
-    #set($limit = $limit - $list.size())
-    #addUsersFromWiki($list $xcontext.mainWikiName $limit)
+#macro (executeMacro)
+  #set($discard = $xwiki.ssx.use('xwiki:XWiki.Macros.Team'))
+  #set($discard = $xwiki.jsx.use('xwiki:XWiki.Macros.Team'))
+  #set($pictureList = {})
+  #set($tag = $wikimacro.parameters.tag)
+  #set($size = $wikimacro.parameters.size)
+  #set($scope = $wikimacro.parameters.scope)
+  #set($letterAvatarBgColor = $wikimacro.parameters.letterAvatarBgColor)
+  #set($letterAvatarFontColor = $wikimacro.parameters.letterAvatarFontColor)
+  #set($requireExternalAuth = $wikimacro.parameters.requireExternalAuth)
+  #set($showUsernames = $wikimacro.parameters.showUsernames)
+  #set($disableTools = $wikimacro.parameters.disableTools)
+  #set($disableLetterAvatars = $wikimacro.parameters.disableLetterAvatars)
+  #set($limit = $wikimacro.parameters.limit)
+  #if("$!size" == "")
+    #set($size = 60)
   #end
-#end
-{{html wiki=false clean=false}}
-&lt;div class="xwikiteam #if(!$showUsernames)xwikiteam-usernames-hidden#end"&gt;
-  #if ($list.size() &gt; 0)
-    &lt;ul class="xwikiteam-ul"&gt;
-      #foreach($user in $list)
-        #avatar($user $size $disableLetterAvatars $letterAvatarBgColor $letterAvatarFontColor)
+  #if("$!scope" == "")
+    #set($scope = "auto")
+  #end
+  #if($scope == "auto")
+    #if($xcontext.database != $xcontext.mainWikiName &amp;&amp; "$!services.wiki" != '')
+      #set ($wikiUserScope = $services.wiki.user.getUserScope($services.wiki.currentWikiId))
+      #if($wikiUserScope == 'GLOBAL_ONLY')
+        #set($scope = 'global')
+      #elseif($wikiUserScope == 'LOCAL_AND_GLOBAL')
+        #set($scope = 'both')
+      #else
+        #set($scope = 'local')
       #end
-      #if(!$disableTools)
-        &lt;li class="xwikiteam-tools-link" hidden="hidden"&gt;
-          &lt;a href="#" role="button" title="$escapetool.xml($services.localization.render('rendering.macro.team.content.options'))"&gt;
-            &lt;span class="fa fa-wrench"&gt;&lt;/span&gt;
-            &lt;span class="sr-only"&gt;$escapetool.xml($services.localization.render('rendering.macro.team.content.options'))&lt;/span&gt;
-          &lt;/a&gt;
-        &lt;/li&gt;
-      #end
-    &lt;/ul&gt;
-    &lt;div class="xwikiteam-tools" hidden="hidden"&gt;
-      &lt;input class="xwikiteam-filter" type="text" placeholder="$escapetool.xml($services.localization.render('rendering.macro.team.content.filter'))" /&gt;
-      &lt;label&gt;
-        &lt;input
-          class="xwikiteam-show-username-checkbox"
-          type="checkbox"
-          #if($showUsernames)checked="checked"#end
-        /&gt;
-        $escapetool.xml($services.localization.render('rendering.macro.team.content.showUsernames'))
-      &lt;/label&gt;
-    &lt;/div&gt;
+    #else
+      #set($scope = 'global')
+    #end
+  #end
+  #if($scope == "both" &amp;&amp; $xcontext.database == $xcontext.mainWikiName)
+    #set($scope = "global")
+  #end
+  #if("$!letterAvatarBgColor" == "")
+    #set($letterAvatarBgColor = "#0A6")
+  #end
+  #if("$!letterAvatarFontColor" == "")
+    #set($letterAvatarFontColor = "white")
+  #end
+  #if("$!requireExternalAuth" == "" || "$!requireExternalAuth" == "false" || "$!requireExternalAuth" == "0")
+    #set($requireExternalAuth = false)
+  #end
+  #if("$!showUsernames" == "" || "$!showUsernames" == "false" || "$!showUsernames" == "0")
+    #set($showUsernames = false)
+  #end
+  #if("$!disableTools" == "" || "$!disableTools" == "false" || "$!disableTools" == "0")
+    #set($disableTools = false)
+  #end
+  #if("$!disableLetterAvatars" == "" || "$!disableLetterAvatars" == "false" || "$!disableLetterAvatars" == "0")
+    #set($disableLetterAvatars = false)
+  #end
+  #if("$!limit" == "")
+    #set($limit = 100)
+  #end
+  #if(!$tag || $tag == "")
+    #set($tagselect = "")
+    #set($tagwhere = "")
   #else
-    &lt;p&gt;$escapetool.xml($services.localization.render('rendering.macro.team.content.noUsers'))&lt;/p&gt;
+    #set($tagselect = ",
+        BaseObject as obj3,
+        DBStringListProperty as tagprop
+      JOIN
+        tagprop.list list
+    ")
+    #set($tagwhere = " and
+      doc.fullName = obj3.name and
+      obj3.className = 'XWiki.TagClass' and
+      obj3.id = tagprop.id.id and
+      tagprop.id.name = 'tags' and
+      list = '$tag'
+    ")
   #end
-&lt;/div&gt;
-{{/html}}
+  #set($hql = ",
+      BaseObject as obj
+      #if($requireExternalAuth), BaseObject as obj2 #end,
+      IntegerProperty as prop
+      $tagselect
+    WHERE
+      doc.fullName = obj.name and
+      obj.className = 'XWiki.XWikiUsers'
+      #if($requireExternalAuth) and
+        doc.fullName = obj2.name and (
+          obj2.className = 'XWiki.LDAPProfileClass' or
+          obj2.className = 'XWiki.OIDC.UserClass'
+        )
+      #end and
+      obj.id = prop.id.id and
+      prop.id.name = 'active' and
+      prop.value = 1
+      $tagwhere
+    ORDER BY doc.name
+  ")
+  #set($list = [])
+  #if ($scope == "global")
+    #addUsersFromWiki($list $xcontext.mainWikiName $limit)
+  #elseif ($scope == "local")
+    #addUsersFromWiki($list $services.wiki.currentWikiId $limit)
+  #elseif ($scope == "both")
+    #addUsersFromWiki($list $services.wiki.currentWikiId $limit)
+    #if($list.size() &lt; $limit)
+      #set($limit = $limit - $list.size())
+      #addUsersFromWiki($list $xcontext.mainWikiName $limit)
+    #end
+  #end
+  {{html wiki=false clean=false}}
+  &lt;div class="xwikiteam #if(!$showUsernames)xwikiteam-usernames-hidden#end"&gt;
+    #if ($list.size() &gt; 0)
+      &lt;ul class="xwikiteam-ul"&gt;
+        #foreach($user in $list)
+          #avatar($user $size $disableLetterAvatars $letterAvatarBgColor $letterAvatarFontColor)
+        #end
+        #if(!$disableTools)
+          &lt;li class="xwikiteam-tools-link" hidden="hidden"&gt;
+            &lt;a href="#" role="button" title="$escapetool.xml($services.localization.render('rendering.macro.team.content.options'))"&gt;
+              &lt;span class="fa fa-wrench"&gt;&lt;/span&gt;
+              &lt;span class="sr-only"&gt;$escapetool.xml($services.localization.render('rendering.macro.team.content.options'))&lt;/span&gt;
+            &lt;/a&gt;
+          &lt;/li&gt;
+        #end
+      &lt;/ul&gt;
+      &lt;div class="xwikiteam-tools" hidden="hidden"&gt;
+        &lt;input class="xwikiteam-filter" type="text" placeholder="$escapetool.xml($services.localization.render('rendering.macro.team.content.filter'))" /&gt;
+        &lt;label&gt;
+          &lt;input
+            class="xwikiteam-show-username-checkbox"
+            type="checkbox"
+            #if($showUsernames)checked="checked"#end
+          /&gt;
+          $escapetool.xml($services.localization.render('rendering.macro.team.content.showUsernames'))
+        &lt;/label&gt;
+      &lt;/div&gt;
+    #else
+      &lt;p&gt;$escapetool.xml($services.localization.render('rendering.macro.team.content.noUsers'))&lt;/p&gt;
+    #end
+  &lt;/div&gt;
+  {{/html}}
+#end
+{{/velocity}}
+
+{{include reference="Licenses.Code.VelocityMacros"/}}
+
+{{velocity}}
+## We need to check if there is a valid license because the macro is registered even if the user doesn't have view right
+## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
+## don't have view right on those pages.
+#if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #executeMacro
+#else
+  {{error}}
+    #getMissingLicenseMessage('proMacros.extension.name')
+  {{/error}}
+#end
 {{/velocity}}</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -36,7 +36,9 @@
   <minorEdit>false</minorEdit>
   <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
-  <content>## Button macro
+  <content>proMacros.extension.name=Pro Macros
+
+## Button macro
 rendering.macro.button.name=Button Macro
 rendering.macro.button.description=Insert a noticeable, clickable button on your XWiki page to highlight links and create call to actions!
 rendering.macro.button.parameter.label.name=Label


### PR DESCRIPTION
* add license error for the macros defined in the _XWiki.Macros_ and _Confluence.Macros_ spaces
* move the code inside a `executeMacro` macro and call it only when there is a valid license
![image](https://user-images.githubusercontent.com/22794181/220165550-8d8c986a-3b5d-427d-b893-1319a829d5da.png)

Note: for a better display of the differences, check the `hide whitespaces` in the `diff view` settings modal