### PR TITLE
The content of the columns from stacked user lists is not aligned #113

### DIFF
--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userlist/macro/UserListMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/userlist/macro/UserListMacroParameters.java
@@ -22,6 +22,7 @@ package com.xwiki.macros.userlist.macro;
 import java.util.Arrays;
 import java.util.List;
 
+import org.xwiki.properties.annotation.PropertyAdvanced;
 import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyName;
 
@@ -35,6 +36,11 @@ public class UserListMacroParameters
     private UserReferenceList users;
 
     private List<String> properties = Arrays.asList("avatar", "username");
+
+    /**
+     * User table layout style.
+     */
+    private boolean fixedTableLayout;
 
     /**
      * @return a list of users
@@ -74,5 +80,26 @@ public class UserListMacroParameters
     public void setProperties(List<String> properties)
     {
         this.properties = properties;
+    }
+
+    /**
+     * Sets the user list table layout style to "fixed".
+     *
+     * @param value true if the table layout should be fixed
+     */
+    @PropertyName("fixedTableLayout")
+    @PropertyDescription("Indicates whether the user table should use a fixed layout")
+    @PropertyAdvanced
+    public void setFixedTableLayout(boolean value)
+    {
+        this.fixedTableLayout = value;
+    }
+
+    /**
+     * @return true if the user table should use a fixed layout
+     */
+    public boolean isFixedTableLayout()
+    {
+        return fixedTableLayout;
     }
 }

--- a/xwiki-pro-macros-api/src/main/resources/css/userlist.css
+++ b/xwiki-pro-macros-api/src/main/resources/css/userlist.css
@@ -1,3 +1,14 @@
-.xwiki-userlist-user-avatar {
-  width: 50px;
+.xwiki-userlist-fixed-layout {
+  table-layout: fixed;
+}
+
+/** Make sure table cells do not overflow when containing for instance long e-mail addresses. */
+.xwiki-userlist tr td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.xwiki-userlist tr td.xwiki-userlist-user-avatar {
+  width: 70px;
+  text-align: center;
 }

--- a/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreferencelist/view.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/html_displayer/userreferencelist/view.vm
@@ -32,8 +32,13 @@
 #end
 #if ($displayer.value != $NULL && $displayer.value.size() > 0)
   #set ($propertyNames = $displayer.parameters.properties.split(','))
+  #set ($fixedTableLayout = $displayer.parameters.fixedTableLayout)
+  #set ($userTableCssClass = 'xwiki-userlist')
+  #if ("$!fixedTableLayout" == 'true')
+    #set ($userTableCssClass = "$userTableCssClass xwiki-userlist-fixed-layout")
+  #end
   #set ($discard = $xwiki.ssrx.use('css/userlist.css'))
-  <table class="xwiki-userlist">
+  <table class="$userTableCssClass">
     #foreach ($user in $displayer.value)
       #if ($xwiki.exists($user) && $services.security.authorization.hasAccess('view', $user))
         #set ($userDoc = $xwiki.getDocument($user))

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -153,6 +153,8 @@ rendering.macro.userList.parameter.users.name=Users
 rendering.macro.userList.parameter.users.description=List of users to be displayed
 rendering.macro.userList.parameter.properties.name=Properties
 rendering.macro.userList.parameter.properties.description=List of user properties to be displayed
+rendering.macro.userList.parameter.fixedTableLayout.name=Fixed table layout
+rendering.macro.userList.parameter.fixedTableLayout.description=If the user table should have fixed column width across tables displaying the same user properties
 rendering.macro.userList.isEmpty=The User List macro has an empty user list.
 rendering.macro.userList.invalidUser=User {0} does not exist or is not viewable.</content>
   <object>


### PR DESCRIPTION
- Introduce a new macro parameter "fixed table layout" (boolean, defaulting to false)
- Update userList CSS for ellipsing the text when a cell overflows