### PR TITLE
Adapt the attachments macro to the new livetable attachments view #112

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -327,10 +327,6 @@ Not every parameters supported by the Confluence macro are supported by this bri
   #template('attachment_macros.vm')
   #template('display_macros.vm')
   #initRequiredSkinExtensions()
-  ## $xwiki.jsfx.use('uicomponents/widgets/upload.js', {'forceSkinAction': true, 'language': ${xcontext.locale}})
-  ## $xwiki.ssfx.use('uicomponents/widgets/upload.css', true)
-  ## $xwiki.jsfx.use('js/xwiki/viewers/attachments.js', {'forceSkinAction': true, 'language': ${xcontext.locale}})
-  ## $xwiki.jsx.use('Confluence.Macros.Attachments', {'language': ${xcontext.locale}})
   #set ($confluenceAttachmentMacroIndex = $confluenceAttachmentMacroIndex + 1)
   #set ($confluenceAttachmentMacroId = "confluenceAttachments$confluenceAttachmentMacroIndex")
   ##
@@ -409,7 +405,6 @@ Not every parameters supported by the Confluence macro are supported by this bri
   #end
 
   {{html clean="false" wiki="true"}}
-    ## #showConfluenceAttachmentsLiveData($document 'confluenceAttachments')
     #showConfluenceAttachments($document)
   {{/html}}
 

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -43,6 +43,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
 * {{{ labels }}} is not supported since XWiki does not support attachment tags
 * {{{ preview }}} does not make sense for the XWiki macro as attachments are displayed differently
 * {{{ old }}} has not been implemented in this bridge macro because it does not make really sense for XWiki
+* {{{ upload }}} has not been implemented yet because it conflicts with the standard attachment panel upload
 * {{{ "created date" }}} value of the {{{ sortBy }}} property behave the same way as the {{{ "date" }}} value
 
 = Parameters =
@@ -51,7 +52,6 @@ Not every parameters supported by the Confluence macro are supported by this bri
 |**patterns**|Comma-separated list of regular expressions, used to filter attachments by name.|No| 
 |**sortBy**|Sort attachments by {{{ date }}}, {{{ size }}} or {{{ name }}}|No|{{{ date }}}
 |**sortOrder**|Sort attachments in {{{ ascending }}} or {{{ descending }}} order|No|{{{ ascending }}}
-|**upload**|Allow users to attach new files|No|{{{ true }}}
 |**page**|Pages containing the attachments to display. Current page if empty.|No| 
 
 = Example Usage =
@@ -63,246 +63,6 @@ Not every parameters supported by the Confluence macro are supported by this bri
   sortBy="name"
 /}}
 {{/code}}</content>
-  <object>
-    <name>Confluence.Macros.Attachments</name>
-    <number>0</number>
-    <className>XWiki.JavaScriptExtension</className>
-    <guid>3d368173-f007-4ddb-830f-f475821ff8d8</guid>
-    <class>
-      <name>XWiki.JavaScriptExtension</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <cache>
-        <cache>0</cache>
-        <defaultValue>long</defaultValue>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>cache</name>
-        <number>5</number>
-        <prettyName>Caching policy</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>long|short|default|forbid</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </cache>
-      <code>
-        <contenttype>PureText</contenttype>
-        <disabled>0</disabled>
-        <editor>PureText</editor>
-        <name>code</name>
-        <number>2</number>
-        <prettyName>Code</prettyName>
-        <rows>20</rows>
-        <size>50</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </code>
-      <name>
-        <disabled>0</disabled>
-        <name>name</name>
-        <number>1</number>
-        <prettyName>Name</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </name>
-      <parse>
-        <disabled>0</disabled>
-        <displayFormType>select</displayFormType>
-        <displayType>yesno</displayType>
-        <name>parse</name>
-        <number>4</number>
-        <prettyName>Parse content</prettyName>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
-      </parse>
-      <use>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>use</name>
-        <number>3</number>
-        <prettyName>Use this extension</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>currentPage|onDemand|always</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </use>
-    </class>
-    <property>
-      <cache>long</cache>
-    </property>
-    <property>
-      <code>require(['jquery', 'xwiki-events-bridge'], function ($) {
-  $('#xwikiuploadfile').on('xwiki:html5upload:message', function (event, data) {
-    if (data.content === 'UPLOAD_FINISHED' &amp;&amp; data.type === 'done') {
-      location.reload();
-    }
-  });
-});
-</code>
-    </property>
-    <property>
-      <name/>
-    </property>
-    <property>
-      <parse>0</parse>
-    </property>
-    <property>
-      <use>onDemand</use>
-    </property>
-  </object>
-  <object>
-    <name>Confluence.Macros.Attachments</name>
-    <number>0</number>
-    <className>XWiki.StyleSheetExtension</className>
-    <guid>8a8f1c65-649d-41b2-ab48-778c676f24cd</guid>
-    <class>
-      <name>XWiki.StyleSheetExtension</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <cache>
-        <cache>0</cache>
-        <defaultValue>long</defaultValue>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>cache</name>
-        <number>5</number>
-        <prettyName>Caching policy</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>long|short|default|forbid</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </cache>
-      <code>
-        <contenttype>PureText</contenttype>
-        <disabled>0</disabled>
-        <editor>PureText</editor>
-        <name>code</name>
-        <number>2</number>
-        <prettyName>Code</prettyName>
-        <rows>20</rows>
-        <size>50</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </code>
-      <contentType>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>contentType</name>
-        <number>6</number>
-        <prettyName>Content Type</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>CSS|LESS</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </contentType>
-      <name>
-        <disabled>0</disabled>
-        <name>name</name>
-        <number>1</number>
-        <prettyName>Name</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </name>
-      <parse>
-        <disabled>0</disabled>
-        <displayFormType>select</displayFormType>
-        <displayType>yesno</displayType>
-        <name>parse</name>
-        <number>4</number>
-        <prettyName>Parse content</prettyName>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
-      </parse>
-      <use>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>use</name>
-        <number>3</number>
-        <prettyName>Use this extension</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>currentPage|onDemand|always</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </use>
-    </class>
-    <property>
-      <cache>long</cache>
-    </property>
-    <property>
-      <code>.confluence-attachment-macro {
-  .upload-response {
-    display: none;
-  }
-
-  #AddAttachment {
-    margin-top: 15px;
-
-    #attachform {
-      .buttonwrapper {
-        display: none;
-      }
-    }
-  }
-}</code>
-    </property>
-    <property>
-      <contentType>LESS</contentType>
-    </property>
-    <property>
-      <name/>
-    </property>
-    <property>
-      <parse>0</parse>
-    </property>
-    <property>
-      <use>onDemand</use>
-    </property>
-  </object>
   <object>
     <name>Confluence.Macros.Attachments</name>
     <number>0</number>
@@ -343,7 +103,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -363,6 +123,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>code</name>
         <number>10</number>
         <prettyName>Macro code</prettyName>
+        <restricted>0</restricted>
         <rows>20</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -375,6 +136,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>contentDescription</name>
         <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -418,15 +180,24 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <values>Optional|Mandatory|No content</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </contentType>
-      <defaultCategory>
+      <defaultCategories>
+        <cache>0</cache>
         <disabled>0</disabled>
-        <name>defaultCategory</name>
+        <displayType>input</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>defaultCategories</name>
         <number>4</number>
-        <prettyName>Default category</prettyName>
-        <size>30</size>
+        <prettyName>Default categories</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </defaultCategory>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </defaultCategories>
       <description>
         <contenttype>PureText</contenttype>
         <disabled>0</disabled>
@@ -434,6 +205,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>3</number>
         <prettyName>Macro description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -507,50 +279,8 @@ Not every parameters supported by the Confluence macro are supported by this bri
     </property>
     <property>
       <code>{{velocity output="false"}}
-#macro (filterAndSortAttachments $attachmentsFiltered $invalidSortBy $invalidSortOrder)
-  $xwiki.ssx.use('Confluence.Macros.Attachments')
-  $xwiki.jsx.use('Confluence.Macros.Attachments')
-  #if ("$!{request.forceTestRights}" == "1")#template("xwikivars.vm")#end
-  #template('attachment_macros.vm')
-  ## Get attachments
-  #if ("$!wikimacro.parameters.tags" != '')
-    #set ($tags = $!wikimacro.parameters.tags.split(','))
-    #set ($pageReferenceSet = $collectiontool.getSet())
-    #foreach ($tag in $tags)
-      #set ($references = $xwiki.tag.getDocumentsWithTag("$tag"))
-      #set ($discard = $pageReferenceSet.addAll($references))
-    #end
-    #set ($attachments = [])
-    #foreach ($pageReference in $pageReferenceSet)
-      #set ($document = $xwiki.getDocument($pageReference))
-      #set ($documentAttachments = $document.attachmentList)
-      #set ($discard = $attachments.addAll($documentAttachments))
-    #end
-  #else
-    #set ($attachments = $doc.attachmentList)
-    #if ("$!wikimacro.parameters.page" != '')
-      #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
-      #set ($attachments = $document.attachmentList)
-    #end
-  #end
-  ## Filter attachments
-  #set ($confluencePatterns = "$!wikimacro.parameters.patterns")
-  #if ($confluencePatterns == '')
-    #set($attachmentsFiltered = $attachments)
-  #else
-    #set ($patterns = $!confluencePatterns.split(','))
-    #set($attachmentsFiltered = [])
-    #foreach ($attachment in $attachments)
-      #foreach ($pattern in $patterns)
-        #set ($matches = $attachment.filename.matches("(?i)$!pattern"))
-        #if ($matches)
-          #set ($discard = $attachmentsFiltered.add($attachment))
-          #break
-        #end
-      #end
-    #end
-  #end
-  ## Sort attachments
+#macro (getLiveDataSort $return)
+  ##property
   #set ($confluenceSortBy = "$!wikimacro.parameters.sortBy")
   #set ($invalidSortBy = false)
   #if ($confluenceSortBy == 'date')
@@ -564,6 +294,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
   #else
     #set ($invalidSortBy = true)
   #end
+  ## order
   #set ($confluenceSortOrder = "$!wikimacro.parameters.sortOrder")
   #set ($invalidSortOrder = false)
   #set ($reverseSortOrderProperties = ['filesize', 'date'])
@@ -580,101 +311,108 @@ Not every parameters supported by the Confluence macro are supported by this bri
       #set ($sortOrder = 'desc')
     #end
   #else
-    #set ($invalidSortOrder = false)
+    #set ($invalidSortOrder = true)
   #end
-  #set ($attachmentsFiltered = $collectiontool.sort($attachmentsFiltered, "$sortBy:$sortOrder"))
+  ## return
+  #if ($invalidSortBy || $invalidSortOrder)
+    #setVariable("$return", {})
+  #else
+    #setVariable("$return", "$sortBy:$sortOrder")
+  #end
 #end
 
-#macro (executeMacro)
-  #filterAndSortAttachments($attachmentsFiltered $invalidSortBy $invalidSortOrder)
+#set ($confluenceAttachmentMacroIndex = -1)
+## Code taken and adapted
+#macro (showConfluenceAttachments $document)
+  #template('attachment_macros.vm')
+  #template('display_macros.vm')
+  #initRequiredSkinExtensions()
+  ## $xwiki.jsfx.use('uicomponents/widgets/upload.js', {'forceSkinAction': true, 'language': ${xcontext.locale}})
+  ## $xwiki.ssfx.use('uicomponents/widgets/upload.css', true)
+  ## $xwiki.jsfx.use('js/xwiki/viewers/attachments.js', {'forceSkinAction': true, 'language': ${xcontext.locale}})
+  ## $xwiki.jsx.use('Confluence.Macros.Attachments', {'language': ${xcontext.locale}})
+  #set ($confluenceAttachmentMacroIndex = $confluenceAttachmentMacroIndex + 1)
+  #set ($confluenceAttachmentMacroId = "confluenceAttachments$confluenceAttachmentMacroIndex")
+  ##
+  #showConfluenceAttachmentsLiveData($document $confluenceAttachmentMacroId)
+#end
+
+## Display a liveData with attachments from the specified document.
+#macro (showConfluenceAttachmentsLiveData $attachmentsDoc $liveDataId)
+  #set ($liveDataConfig = {
+    'meta': {
+      'propertyDescriptors': [
+        { 'id': 'mimeType', 'displayer': 'html'},
+        { 'id': 'filename', 'displayer': 'html' },
+        { 'id': 'filesize', 'displayer': 'html' },
+        { 'id': 'date', 'filter': 'date'},
+        { 'id': 'author', 'displayer': 'html' }
+      ],
+      'entryDescriptor': {
+        'idProperty': 'id'
+      }
+    }
+  })
+
+  #if ("$!wikimacro.parameters.patterns" != '')
+    #set ($liveDataConfig.query = {})
+    #set ($liveDataConfig.query.filters = [
+      {
+        "property": "filename",
+        "matchAll": true,
+        "constraints": []
+      }
+    ])
+    #set ($filters = $stringtool.split($wikimacro.parameters.patterns, ','))
+    #foreach ($filter in $filters)
+      #set ($discard = $liveDataConfig.query.filters[0].constraints.add(
+        { "operator": "contains", "value": "$!filter.trim()" }
+      ))
+    #end
+  #end
+  #set ($sourceParameters = $escapetool.url({
+    'template': 'xpart.vm',
+    'translationPrefix': 'core.viewers.attachments.livetable.',
+    'className': 'XWiki.AllAttachments',
+    "\$doc": "$attachmentsDoc",
+    'vm': 'attachmentsjson.vm'
+  }))
+  #getLiveDataSort($liveDataSort)
   #if ($invalidSortBy)
-    {{error}}
-      Attachment macro error: sortBy parameter must be one of 'date', 'size', or 'name'
-    {{/error}}
-    #break
+    {{warning}}
+      Attachment macro: sortBy parameter must be one of 'date', 'size', or 'name'
+    {{/warning}}
   #end
   #if ($invalidSortOrder)
-    {{error}}
-      Attachment macro error: sortOrder parameter must be one of 'ascending' or 'descending'
-    {{/error}}
-    #break
+    {{warning}}
+      Attachment macro: sortOrder parameter must be one of 'ascending' or 'descending'
+    {{/warning}}
   #end
-  ## Display attachments
-  {{html clean="false"}}
-    &lt;div class="confluence-attachment-macro"&gt;
-      #if ($attachmentsFiltered.size() &gt; 0)
-        #displayAttachments($attachmentsFiltered)
-        #deleteAttachmentModal()
-      #else
-        &lt;p class="noitems"&gt;
-          $!escapetool.xml($services.localization.render('core.viewers.attachments.noAttachments'))
-        &lt;/p&gt;
-      #end
 
-      ## Allow upload
-      #set ($upload = "$!wikimacro.parameters.upload")
-      #if ($upload == 'true' &amp;&amp; ($hasEdit || $hasAdmin) &amp;&amp; $xcontext.action == 'view')
-        &lt;form
-          id="AddAttachment"
-          action="$doc.getURL("upload")"
-          method="post"
-          enctype="multipart/form-data"
-        &gt;
-          &lt;div&gt;
-            ## CSRF prevention
-            &lt;input
-              type="hidden"
-              name="form_token"
-              value="$!{services.csrf.getToken()}"
-            /&gt;
+  {{liveData
+    id="$liveDataId"
+    properties="mimeType,filename,filesize,date,author"
+    source='liveTable'
+    sourceParameters="$sourceParameters"
+    sort="$liveDataSort"
+    limit=5
+  }}$jsontool.serialize($liveDataConfig){{/liveData}}
 
-            &lt;fieldset id="attachform"&gt;
-              &lt;legend&gt;
-                $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.title'))
-              &lt;/legend&gt;
+  {{html clean="false"}}#deleteAttachmentModal(){{/html}}
+#end
 
-              &lt;div class="fileupload-field"&gt;
-                &lt;label
-                  class="hidden"
-                  for="xwikiuploadfile"
-                &gt;
-                  $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
-                &lt;/label&gt;
 
-                &lt;input
-                  id="xwikiuploadfile"
-                  class="uploadFileInput noitems"
-                  type="file"
-                  name="filepath"
-                  size="40"
-                  data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))"
-                /&gt;
-              &lt;/div&gt;
+#macro (executeMacro)
+  #set ($document = $doc)
+  #if ("$!wikimacro.parameters.page" != '')
+    #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
+  #end
 
-              &lt;div&gt;
-                &lt;span class="buttonwrapper"&gt;
-                  &lt;input
-                    class="button btn btn-primary"
-                    type="submit"
-                    value="$!escapetool.xml($services.localization.render('core.viewers.attachments.upload.submit'))"
-                  /&gt;
-                &lt;/span&gt;
-
-                &lt;span class="buttonwrapper"&gt;
-                  &lt;a
-                    class="cancel secondary button btn btn-primary"
-                    href="$doc.getURL()"
-                  &gt;
-                    $!escapetool.xml($services.localization.render('core.viewers.attachments.upload.cancel'))
-                  &lt;/a&gt;
-                &lt;/span&gt;
-              &lt;/div&gt;
-            &lt;/fieldset&gt;
-          &lt;/div&gt;
-        &lt;/form&gt;
-      #end
-    &lt;/div&gt; ## .confluence-attachment-macro
+  {{html clean="false" wiki="true"}}
+    ## #showConfluenceAttachmentsLiveData($document 'confluenceAttachments')
+    #showConfluenceAttachments($document)
   {{/html}}
+
 #end
 {{/velocity}}
 
@@ -704,7 +442,9 @@ Not every parameters supported by the Confluence macro are supported by this bri
       <contentType>No content</contentType>
     </property>
     <property>
-      <defaultCategory>confluence</defaultCategory>
+      <defaultCategories>
+        <value>confluence</value>
+      </defaultCategories>
     </property>
     <property>
       <description>Confluence attachment macro support for XWiki</description>
@@ -753,6 +493,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -807,84 +548,6 @@ Not every parameters supported by the Confluence macro are supported by this bri
   </object>
   <object>
     <name>Confluence.Macros.Attachments</name>
-    <number>3</number>
-    <className>XWiki.WikiMacroParameterClass</className>
-    <guid>28669705-3ae4-42f3-bd3b-0ac932622b2e</guid>
-    <class>
-      <name>XWiki.WikiMacroParameterClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <defaultValue>
-        <disabled>0</disabled>
-        <name>defaultValue</name>
-        <number>4</number>
-        <prettyName>Parameter default value</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </defaultValue>
-      <description>
-        <disabled>0</disabled>
-        <name>description</name>
-        <number>2</number>
-        <prettyName>Parameter description</prettyName>
-        <rows>5</rows>
-        <size>40</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </description>
-      <mandatory>
-        <disabled>0</disabled>
-        <displayFormType>select</displayFormType>
-        <displayType>yesno</displayType>
-        <name>mandatory</name>
-        <number>3</number>
-        <prettyName>Parameter mandatory</prettyName>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
-      </mandatory>
-      <name>
-        <disabled>0</disabled>
-        <name>name</name>
-        <number>1</number>
-        <prettyName>Parameter name</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </name>
-      <type>
-        <disabled>0</disabled>
-        <name>type</name>
-        <number>5</number>
-        <prettyName>Parameter type</prettyName>
-        <size>60</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </type>
-    </class>
-    <property>
-      <defaultValue>true</defaultValue>
-    </property>
-    <property>
-      <description>If selected, the list of attachments will include options allowing users to browse for, and attach, new files.</description>
-    </property>
-    <property>
-      <mandatory>0</mandatory>
-    </property>
-    <property>
-      <name>upload</name>
-    </property>
-    <property>
-      <type>java.lang.Boolean</type>
-    </property>
-  </object>
-  <object>
-    <name>Confluence.Macros.Attachments</name>
     <number>4</number>
     <className>XWiki.WikiMacroParameterClass</className>
     <guid>fef28103-46af-42a6-8adf-6ce3c11f2b89</guid>
@@ -911,6 +574,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -989,6 +653,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -1067,6 +732,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -1145,6 +811,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
         <name>description</name>
         <number>2</number>
         <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>


### PR DESCRIPTION
* Adapt attachment macro to use the new livedata attachments view
* Remove `upload` parameter for now as it conflicts with standard attachments panel

There is also a slight issue with the `patterns` parameter. From the confluence side, this parameter expects a regex pattern in order to filter attachments. However, the livedata only supports `equals`, `startsWith` and `contains` filter operators for the filename field, so there is no direct equivalent to this regex filtering. This will make attachment macros to likely not display the expected files when that `patterns` parameter was set from imported confluence pages.

We might want to add  a new `pattern` operator to the attachment livedata source to address this issue.