### PR TITLE
The Button macro deletes followup content when inserted from wysiwyg #124

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
@@ -323,7 +323,10 @@ $services.localization.render('rendering.macro.button.description')
   #darken($colors, $darkenedColors)
   {{html clean=false}}
   ## #124: The Button macro deletes followup content when inserted from wysiwyg
-  ## If not in inline mode, wrap inside block in order to fix issue
+  ## Wrap the macro output inside a block element if the context where the macro is inserted is not inline, e.g. if the
+  ## macro is inserted between paragraphs rather than between the text of a paragraph. Otherwise the generated HTML is
+  ## invalid which breaks the WYSIWYG editing because the browser tries to fix the invalid HTML and messes up the macro
+  ## output markers that protect the macro output.
   #if (!$wikimacro.context.isInline())&lt;p&gt;#end
   &lt;a href="$url" #if($newTab == 'true')target="_blank"#end&gt;
     &lt;button

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
@@ -322,6 +322,9 @@ $services.localization.render('rendering.macro.button.description')
   #set ($darkenedColors = [])
   #darken($colors, $darkenedColors)
   {{html clean=false}}
+  ## #124: The Button macro deletes followup content when inserted from wysiwyg
+  ## If not in inline mode, wrap inside block in order to fix issue
+  #if (!$wikimacro.context.isInline())&lt;p&gt;#end
   &lt;a href="$url" #if($newTab == 'true')target="_blank"#end&gt;
     &lt;button
       style="
@@ -335,6 +338,7 @@ $services.localization.render('rendering.macro.button.description')
       $label
     &lt;/button&gt;
   &lt;/a&gt;
+  #if (!$wikimacro.context.isInline())&lt;/p&gt;#end
   {{/html}}
 #end
 {{/velocity}}


### PR DESCRIPTION
I used [the same fix than for the UserAvatar macro](https://github.com/xwiki/xwiki-platform/commit/be7047798f4029f570e137d3fc7a51fa974ba2f9), which is when the macro is not in inline mode, wrap its content inside a block to ensure inline content will be parsed correctly.