### PR TITLE
 The example usage on the attachments macro page (Confluence.Macros.Attachments) is using the old name of the attachments macro #129

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -58,7 +58,7 @@ Not every parameters supported by the Confluence macro are supported by this bri
 
 
 {{code}}
-{{attachments
+{{confluence_attachments
   patterns=".*png"
   sortBy="name"
 /}}


### PR DESCRIPTION
Renamed reference in example