### PR TITLE
Recently Updated Macro displays an error on pages with different loca…

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Note.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Note.xml
@@ -65,13 +65,13 @@ This is my note with title.
 
 {{code}}
 {{note title="It supports XWiki syntax: "}}
-This is my note with title and a link [[XWiki Store>>https://store.xwiki.com]]
+This is my note with title and a link [[XWiki Store&gt;&gt;https://store.xwiki.com]]
 {{/note}}
 {{/code}}
 
 Result :
 
 {{note title="It supports XWiki syntax: "}}
-This is my note with title and a link [[XWiki Store>>https://store.xwiki.com]]
+This is my note with title and a link [[XWiki Store&gt;&gt;https://store.xwiki.com]]
 {{/note}}</content>
 </xwikidoc>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
@@ -216,8 +216,18 @@
   ## Add data to result
   #foreach ($property in $commentResponse.results)
     #if ($property.propertyname == 'date')
-      #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", $datetool.getLocale(), $datetool.getTimeZone()))
-      #set ($date = $dateFormat.parse($property.propertyvalue_[0]))
+      ## We try to parse the date using the current locale. If if fails, we try with the 'en' locale. If that also
+      ## fails, the date won't be displayed.
+      #try('exception')
+        #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", $datetool.getLocale(), $datetool.getTimeZone()))
+        #set ($date = $dateFormat.parse($property.propertyvalue_[0]))
+      #end
+      #if ($exception)
+        #try()
+          #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", 'en', $datetool.getTimeZone()))
+          #set ($date = $dateFormat.parse($property.propertyvalue_[0]))
+        #end
+      #end
       #set ($discard = $comment.put('date', $date))
     #elseif ($property.propertyname == 'author')
       #set ($discard = $comment.put('author', "$property.propertyvalue_[0]"))

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
@@ -216,17 +216,10 @@
   ## Add data to result
   #foreach ($property in $commentResponse.results)
     #if ($property.propertyname == 'date')
-      ## We try to parse the date using the current locale. If if fails, we try with the 'en' locale. If that also
-      ## fails, the date won't be displayed.
+      #set ($date = $null)
       #try('exception')
-        #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", $datetool.getLocale(), $datetool.getTimeZone()))
+        #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", 'en', $datetool.getTimeZone()))
         #set ($date = $dateFormat.parse($property.propertyvalue_[0]))
-      #end
-      #if ($exception)
-        #try()
-          #set ($dateFormat = $datetool.getDateFormat("EEE MMM dd HH:mm:ss z yyyy", 'en', $datetool.getTimeZone()))
-          #set ($date = $dateFormat.parse($property.propertyvalue_[0]))
-        #end
       #end
       #set ($discard = $comment.put('date', $date))
     #elseif ($property.propertyname == 'author')


### PR DESCRIPTION
…les #151

The issue was caused by the parsing of the comment date extracted from SOLR. Specifically, when parsing the date `Fri Jun 16 08:46:07 EEST 2023`, because the locale was `de` or something else, it was expecting `Freitag` instead of `Friday` to be present in the string.

I also ran the xar format.