### PR TITLE
 The avatars show with different size #140 

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
@@ -730,6 +730,7 @@
           title='$escapedDisplayUser'
           width='$escapedSize'
           height='$escapedSize'
+          style="height: ${escapedSize}px"
         /&gt;
       #end
       &lt;span class='xwikiteam-username'&gt;$escapedDisplayUser&lt;/span&gt;


### PR DESCRIPTION
Fixed the issue where the avatar's height was determined by the size of the photo. The bug was caused by a change in 'https://github.com/xwiki/xwiki-platform/blame/master/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less' where the img tag received the property height: auto;.  To fix this issue, I've overridden the height: auto; with the height given as a parameter to the macro.