### PR TITLE
column macro should work without content. #118 

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
@@ -464,7 +464,7 @@ Content in the column 4
       <contentJavaType>Wiki</contentJavaType>
     </property>
     <property>
-      <contentType>Mandatory</contentType>
+      <contentType>Optional</contentType>
     </property>
     <property>
       <defaultCategory/>


### PR DESCRIPTION
I've changed the content parameter of the macro  to be optional