### PR TITLE
issue157: Viewpdf macro cannot be used inline

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewpdf.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewpdf.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="Confluence.Macros.Viewpdf" locale="">
+<xwikidoc version="1.5" reference="Confluence.Macros.Viewpdf" locale="">
   <web>Confluence.Macros</web>
   <name>Viewpdf</name>
   <language/>
@@ -260,11 +260,13 @@
 #if (!$filename)
   #set ($filename = $xcontext.macro.params.get('name'))
 #end
+#if ($xcontext.macro.context.isInline())(((#end
 #if ($hasPDFViewer)
   {{pdfviewer file="$filename" /}}
 #else
   {{office reference="$filename" /}}
 #end
+#if (${xcontext.macro.context.isInline()}))))#end
 {{/velocity}}</code>
     </property>
     <property>
@@ -292,7 +294,7 @@
       <priority/>
     </property>
     <property>
-      <supportsInlineMode>0</supportsInlineMode>
+      <supportsInlineMode>1</supportsInlineMode>
     </property>
     <property>
       <visibility>Current Wiki</visibility>


### PR DESCRIPTION
- add group markers if the macro is used inline to render the contained macros on block level

[See issue#157](https://github.com/xwikisas/xwiki-pro-macros/issues/157)