### PR TITLE
[Regression] Missing actions for the "Attachments" macro #153

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -66,6 +66,157 @@ Not every parameters supported by the Confluence macro are supported by this bri
   <object>
     <name>Confluence.Macros.Attachments</name>
     <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>5ce8db0a-d360-4725-aa3a-c5d939b48c8c</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>define('xwiki-confluence-attachments-messages', {
+  prefix: 'core.viewers.attachments.delete.',
+  keys: [
+    'inProgress',
+    'done',
+    'error'
+  ]
+});
+
+require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function($, l10n) {
+  //
+  // The delete action methods are similar to the ones from the attachments tab, but couldn't be reused. The problem is
+  // that when the tab is not opened we cannot just load the attachments.js file, since it expects some elements to be
+  // already loaded and it produces errors.
+  //
+
+  /**
+   * Open the delete confirmation modal on liveData attachment delete button.
+   */
+  $(document).on('click', '.confluenceAttachmentsMacro .attachmentActions .actiondelete', function(e) {
+    e.preventDefault();
+    var modal = $(e.currentTarget).closest('.liveData').nextAll('.deleteConfluenceAttachment');
+    modal.data('relatedTarget', e.currentTarget);
+    modal.modal('show');
+  });
+
+  /**
+   * On delete confirmation, delete attachment and refresh liveData.
+   */
+  $(document).on('click', '.confluenceAttachmentsMacro .deleteConfluenceAttachment input.btn-danger', function(e) {
+    e.preventDefault();
+    var modal = $(e.currentTarget).closest('.deleteConfluenceAttachment');
+    var button = $(modal.data('relatedTarget'));
+    var liveData = button.closest('.liveData').data('liveData');
+    var notification;
+
+    $.ajax({
+      url : button.prop('href'),
+      beforeSend : function() {
+        notification = new XWiki.widgets.Notification(l10n['inProgress'], 'inprogress');
+      },
+      success : function() {
+        liveData.updateEntries()
+        notification.replace(new XWiki.widgets.Notification(l10n['done'], 'done'));
+      },
+      error: function() {
+        notification.replace(new XWiki.widgets.Notification(l10n['failed'], 'error'));
+      }
+    })
+  });
+});
+</code>
+    </property>
+    <property>
+      <name>Confluence Attachments Macro</name>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Attachments</name>
+    <number>0</number>
     <className>XWiki.WikiMacroClass</className>
     <guid>e02a27df-6c8d-42bb-85cf-8a9eb6f3d6fe</guid>
     <class>
@@ -309,12 +460,37 @@ Not every parameters supported by the Confluence macro are supported by this bri
   #end
 #end
 
+#macro (deleteConfluenceAttachmentModal)
+  ## Copied from the attachments tab code. The original macro cannot be used, since it will interfere with some js
+  ## specific to attachments tab. Precisely, if the attachments tab is already opened, everything is working correctly.
+  ## If it is not opened, we need to load the attachments.js code anyway, to use it's listeners, but there are parts
+  ## that rightfully assume that some elements are present on the page and errors will occur.
+  &lt;div class="modal fade deleteConfluenceAttachment" tabindex="-1" role="dialog"&gt;
+    &lt;div class="modal-dialog"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal"&gt;&amp;times;&lt;/button&gt;
+          &lt;div class="modal-title"&gt;$services.localization.render('core.viewers.attachments.delete')&lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          &lt;div&gt;$services.localization.render('core.viewers.attachments.delete.confirm')&lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;input type="button" class="btn btn-danger"  data-dismiss="modal"
+            value="$escapetool.xml($services.localization.render('core.viewers.attachments.delete'))"&gt;
+          &lt;input type="button" class="btn btn-default" data-dismiss="modal"
+            value="$escapetool.xml($services.localization.render('cancel'))"&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
+
 #set ($confluenceAttachmentMacroIndex = -1)
 ## Code taken and adapted
 #macro (showConfluenceAttachments $document)
   #template('attachment_macros.vm')
   #template('display_macros.vm')
-  #initRequiredSkinExtensions()
   #set ($confluenceAttachmentMacroIndex = $confluenceAttachmentMacroIndex + 1)
   #set ($confluenceAttachmentMacroId = "confluenceAttachments$confluenceAttachmentMacroIndex")
   ##
@@ -330,7 +506,8 @@ Not every parameters supported by the Confluence macro are supported by this bri
         { 'id': 'filename', 'displayer': 'html' },
         { 'id': 'filesize', 'displayer': 'html' },
         { 'id': 'date', 'filter': 'date'},
-        { 'id': 'author', 'displayer': 'html' }
+        { 'id': 'author', 'displayer': 'html' },
+        { 'id': 'actions', 'displayer': 'html' }
       ],
       'entryDescriptor': {
         'idProperty': 'id'
@@ -375,25 +552,29 @@ Not every parameters supported by the Confluence macro are supported by this bri
 
   {{liveData
     id="$liveDataId"
-    properties="mimeType,filename,filesize,date,author"
+    properties="mimeType,filename,filesize,date,author,actions"
     source='liveTable'
     sourceParameters="$sourceParameters"
     sort="$liveDataSort"
     limit=5
   }}$jsontool.serialize($liveDataConfig){{/liveData}}
 
-  {{html clean="false"}}#deleteAttachmentModal(){{/html}}
+  {{html clean="false"}}#deleteConfluenceAttachmentModal(){{/html}}
 #end
 
 
 #macro (executeMacro)
+  $xwiki.ssfx.use('js/xwiki/viewers/attachments.css', true)
+  #set ($discard = $xwiki.jsx.use("Confluence.Macros.Attachments"))
   #set ($document = $doc)
   #if ("$!wikimacro.parameters.page" != '')
     #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))
   #end
 
   {{html clean="false" wiki="true"}}
-    #showConfluenceAttachments($document)
+    &lt;div class='confluenceAttachmentsMacro'&gt;
+      #showConfluenceAttachments($document)
+    &lt;/div&gt;
   {{/html}}
 
 #end


### PR DESCRIPTION
* add the actions tab
* rewrite some attachments tab js code / velocity macros in order to make them specific to this confluence macro; this is done since the attachments tab is not always opened

Note that this code might need some adjustments after https://github.com/xwikisas/xwiki-pro-macros/issues/131 will be fixed.

For reference, there is https://github.com/xwikisas/application-confluence-migrator-pro/pull/4 where a similar solution was used. But the difference is that in here the `livedata` is manually created an so the `deleteAttachmentModal` is not added by default. Because of this, I can avoid some of the errors described in [here](https://github.com/xwikisas/application-confluence-migrator-pro/pull/4#discussion_r1318201972) by just duplicating some methods