### PR TITLE
[Regression] The attachments list is not displayed on XWiki 14.4.3 (error loading data) #131

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -161,8 +161,8 @@ Not every parameters supported by the Confluence macro are supported by this bri
 });
 
 require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function($, l10n) {
-  var enhanceUploadInputs = function() {
-    $.each($('.confluenceAttachmentsMacro input[type=file]'), function() {
+  var enhanceUploadInputs = function(liveDataElems) {
+    $.each(liveDataElems.find('input[type=file]'), function() {
       // Since the attachments liveData is refreshed on file upload, there is no need for a response container.
       new XWiki.FileUploader(this, {
         'progressAutohide': true,
@@ -173,21 +173,20 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
   };
 
   $(function() {
-    enhanceUploadInputs();
+    enhanceUploadInputs($('.confluenceAttachmentsMacro'));
   })
 
   $(document).on('xwiki:dom:updated', function(e, data) {
-    enhanceUploadInputs();
+    let liveDataElems = $(data.elements).find('.confluenceAttachmentsMacro');
+    enhanceUploadInputs(liveDataElems);
   });
 
   $(document).on('xwiki:html5upload:done', function(e) {
     if ($(e.target).prop('id').startsWith('confluenceAttachments')) {
       // Select the livedata above the upload form.
       const uploadForm = $(e.target).closest('form');
-      let associatedLivedata = uploadForm.prevAll('.liveData').first();
-      // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
-      associatedLivedata = associatedLivedata.length &gt; 0 ?
-        associatedLivedata : uploadForm.prevAll('.xwiki-livedata').first();
+      // The 'xwiki-livedata' CSS class is present only before XWiki version 14.4.
+      let associatedLivedata = uploadForm.prevAll('.liveData, .xwiki-livedata').first();
       // We do not have access to a liveData object before XWiki 14.4.
       if (associatedLivedata.data('liveData') === undefined) {
         location.reload();
@@ -208,9 +207,8 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
    */
   $(document).on('click', '.confluenceAttachmentsMacro .attachmentActions .actiondelete', function(e) {
     e.preventDefault();
-    let liveData = $(e.currentTarget).closest('.liveData');
-    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
-    liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
+    // The 'xwiki-livedata' CSS class is present only before XWiki version 14.4.
+    let liveData = $(e.currentTarget).closest('.liveData, .xwiki-livedata');
     var modal = liveData.nextAll('.deleteConfluenceAttachment');
     modal.data('relatedTarget', e.currentTarget);
     modal.modal('show');
@@ -223,9 +221,8 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     e.preventDefault();
     var modal = $(e.currentTarget).closest('.deleteConfluenceAttachment');
     var button = $(modal.data('relatedTarget'));
-    let liveData = button.closest('.liveData');
-    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
-    liveData = liveData.length &gt; 0 ? liveData : button.closest('.xwiki-livedata');
+    // The 'xwiki-livedata' CSS class is present only before XWiki version 14.4.
+    let liveData = button.closest('.liveData, .xwiki-livedata');
     var notification;
 
     $.ajax({

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -368,7 +368,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
       <code>.confluenceAttachmentsMacro legend {
   font-size: 1em;
 }
- /* These should be deleted after upgrading to a XWiki parent &gt;= 14.10. */
+ /* These should be deleted after upgrading to a XWiki parent &gt;= 14.6. */
 .attachmentMimeType {
   color: $theme.textSecondaryColor;
   font-size: 32px;

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -176,12 +176,21 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     enhanceUploadInputs();
   })
 
+  $(document).on('xwiki:dom:updated', function(e, data) {
+    enhanceUploadInputs();
+  });
+
   $(document).on('xwiki:html5upload:done', function(e) {
     if ($(e.target).prop('id').startsWith('confluenceAttachments')) {
       // Select the livedata above the upload form.
-      const associatedLivedata = $(e.target).closest('form').prevAll('.liveData')[0];
-      const liveDataObj = $(associatedLivedata).data('liveData');
-      liveDataObj.updateEntries();
+      let associatedLivedata = $(e.target).closest('form').prevAll('.liveData')[0];
+      // We do not have access to a liveData object before XWiki 14.4.
+      if (associatedLivedata == undefined) {
+        location.reload();
+      } else {
+        const liveDataObj = $(associatedLivedata).data('liveData');
+        liveDataObj.updateEntries();
+      }
     }
   });
 
@@ -196,7 +205,10 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
    */
   $(document).on('click', '.confluenceAttachmentsMacro .attachmentActions .actiondelete', function(e) {
     e.preventDefault();
-    var modal = $(e.currentTarget).closest('.liveData').nextAll('.deleteConfluenceAttachment');
+    let liveData = $(e.currentTarget).closest('.liveData');
+    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.10.
+    liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
+    var modal = liveData.nextAll('.deleteConfluenceAttachment');
     modal.data('relatedTarget', e.currentTarget);
     modal.modal('show');
   });
@@ -208,7 +220,9 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     e.preventDefault();
     var modal = $(e.currentTarget).closest('.deleteConfluenceAttachment');
     var button = $(modal.data('relatedTarget'));
-    var liveData = button.closest('.liveData').data('liveData');
+    let liveData = button.closest('.liveData');
+    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.10.
+    liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
     var notification;
 
     $.ajax({
@@ -217,8 +231,12 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
         notification = new XWiki.widgets.Notification(l10n['inProgress'], 'inprogress');
       },
       success : function() {
-        liveData.updateEntries()
-        notification.replace(new XWiki.widgets.Notification(l10n['done'], 'done'));
+        if (liveData.length &gt; 0) {
+          liveData.data('liveData').updateEntries()
+          notification.replace(new XWiki.widgets.Notification(l10n['done'], 'done'));
+        } else {
+          location.reload();
+        }
       },
       error: function() {
         notification.replace(new XWiki.widgets.Notification(l10n['failed'], 'error'));
@@ -345,6 +363,18 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     <property>
       <code>.confluenceAttachmentsMacro legend {
   font-size: 1em;
+}
+ /* These should be deleted after upgrading to a XWiki parent &gt;= 14.10. */
+.attachmentMimeType {
+  color: $theme.textSecondaryColor;
+  font-size: 32px;
+  height: 32px;
+  line-height: 32px;
+  text-align: center;
+}
+.attachmentMimeType img {
+  max-height: 32px;
+  max-width: 48px;
 }</code>
     </property>
     <property>
@@ -635,7 +665,6 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
 #set ($confluenceAttachmentMacroIndex = -1)
 ## Code taken and adapted
 #macro (showConfluenceAttachments $document)
-  #template('attachment_macros.vm')
   #template('display_macros.vm')
   #set ($confluenceAttachmentMacroIndex = $confluenceAttachmentMacroIndex + 1)
   #set ($confluenceAttachmentMacroId = "confluenceAttachments$confluenceAttachmentMacroIndex")
@@ -700,12 +729,13 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
       ))
     #end
   #end
+  ## After upgrading to a XWiki parent with a version &gt;= 14.10, the resultPage parameter should be replaced back by
+  ## {'template': 'xpart.vm', 'vm': 'attachmentsjson.vm'}.
   #set ($sourceParameters = $escapetool.url({
-    'template': 'xpart.vm',
     'translationPrefix': 'core.viewers.attachments.livetable.',
     'className': 'XWiki.AllAttachments',
     "\$doc": "$attachmentsDoc",
-    'vm': 'attachmentsjson.vm'
+    'resultPage': 'Confluence.Macros.AttachmentsJSON'
   }))
   #getLiveDataSort($liveDataSort)
   #if ($invalidSortBy)

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -746,8 +746,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     'className': 'XWiki.AllAttachments',
     "\$doc": "$attachmentsDoc"
   })
-  ## Since attachmentsjson.vm was added starting with XWiki 14.6, we use a copy of its code for backwards
-  ## compatibility.
+  ## Since the correct attachmentsjson.vm was added in XWiki 14.8, we use a copy of its code for backwards compatibility.
   #supportsAttachJSON($supportsAttachJSON)
   #if ($supportsAttachJSON)
     #set ($discard = $sourceParams.put('template', 'xpart.vm'))

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -183,12 +183,16 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
   $(document).on('xwiki:html5upload:done', function(e) {
     if ($(e.target).prop('id').startsWith('confluenceAttachments')) {
       // Select the livedata above the upload form.
-      let associatedLivedata = $(e.target).closest('form').prevAll('.liveData')[0];
+      const uploadForm = $(e.target).closest('form');
+      let associatedLivedata = uploadForm.prevAll('.liveData').first();
+      // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
+      associatedLivedata = associatedLivedata.length &gt; 0 ?
+        associatedLivedata : uploadForm.prevAll('.xwiki-livedata').first();
       // We do not have access to a liveData object before XWiki 14.4.
-      if (associatedLivedata === undefined || $(associatedLivedata).data('liveData') === undefined) {
+      if (associatedLivedata.data('liveData') === undefined) {
         location.reload();
       } else {
-        $(associatedLivedata).data('liveData').updateEntries();
+        associatedLivedata.data('liveData').updateEntries();
       }
     }
   });
@@ -221,7 +225,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     var button = $(modal.data('relatedTarget'));
     let liveData = button.closest('.liveData');
     // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
-    liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
+    liveData = liveData.length &gt; 0 ? liveData : button.closest('.xwiki-livedata');
     var notification;
 
     $.ajax({
@@ -230,8 +234,9 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
         notification = new XWiki.widgets.Notification(l10n['inProgress'], 'inprogress');
       },
       success : function() {
-        if (liveData.length &gt; 0 &amp;&amp; liveData.data('liveData') !== undefined) {
-          liveData.data('liveData').updateEntries()
+        // We do not have access to a liveData object before XWiki 14.4.
+        if (liveData.data('liveData') !== undefined) {
+          liveData.data('liveData').updateEntries();
           notification.replace(new XWiki.widgets.Notification(l10n['done'], 'done'));
         } else {
           location.reload();

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Attachments.xml
@@ -185,11 +185,10 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
       // Select the livedata above the upload form.
       let associatedLivedata = $(e.target).closest('form').prevAll('.liveData')[0];
       // We do not have access to a liveData object before XWiki 14.4.
-      if (associatedLivedata == undefined) {
+      if (associatedLivedata === undefined || $(associatedLivedata).data('liveData') === undefined) {
         location.reload();
       } else {
-        const liveDataObj = $(associatedLivedata).data('liveData');
-        liveDataObj.updateEntries();
+        $(associatedLivedata).data('liveData').updateEntries();
       }
     }
   });
@@ -206,7 +205,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
   $(document).on('click', '.confluenceAttachmentsMacro .attachmentActions .actiondelete', function(e) {
     e.preventDefault();
     let liveData = $(e.currentTarget).closest('.liveData');
-    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.10.
+    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
     liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
     var modal = liveData.nextAll('.deleteConfluenceAttachment');
     modal.data('relatedTarget', e.currentTarget);
@@ -221,7 +220,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     var modal = $(e.currentTarget).closest('.deleteConfluenceAttachment');
     var button = $(modal.data('relatedTarget'));
     let liveData = button.closest('.liveData');
-    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.10.
+    // This should be deleted after upgrading the XWiki parent to a version &gt;= 14.4.
     liveData = liveData.length &gt; 0 ? liveData : $(e.currentTarget).closest('.xwiki-livedata');
     var notification;
 
@@ -231,7 +230,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
         notification = new XWiki.widgets.Notification(l10n['inProgress'], 'inprogress');
       },
       success : function() {
-        if (liveData.length &gt; 0) {
+        if (liveData.length &gt; 0 &amp;&amp; liveData.data('liveData') !== undefined) {
           liveData.data('liveData').updateEntries()
           notification.replace(new XWiki.widgets.Notification(l10n['done'], 'done'));
         } else {
@@ -695,6 +694,14 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
   #end
 #end
 
+#macro (supportsAttachJSON $supportsAttachJSON)
+  ## The attachments.json code uses macros from attachment_macro.vm, so the existence of the attachments livedata macro
+  ## is an indicator that the template exists and is adapted for livedata.
+  #template('attachment_macros.vm')
+  #set ($macroResult = "#showAttachmentsLiveData($doc 'id')")
+  #set ($supportsAttachJSON = $macroResult.startsWith('{{liveData'))
+#end
+
 ## Display a liveData with attachments from the specified document.
 #macro (showConfluenceAttachmentsLiveData $attachmentsDoc $liveDataId)
   #set ($liveDataConfig = {
@@ -729,14 +736,20 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
       ))
     #end
   #end
-  ## After upgrading to a XWiki parent with a version &gt;= 14.10, the resultPage parameter should be replaced back by
-  ## {'template': 'xpart.vm', 'vm': 'attachmentsjson.vm'}.
-  #set ($sourceParameters = $escapetool.url({
+  #set ($sourceParams = {
     'translationPrefix': 'core.viewers.attachments.livetable.',
     'className': 'XWiki.AllAttachments',
-    "\$doc": "$attachmentsDoc",
-    'resultPage': 'Confluence.Macros.AttachmentsJSON'
-  }))
+    "\$doc": "$attachmentsDoc"
+  })
+  ## Since attachmentsjson.vm was added starting with XWiki 14.6, we use a copy of its code for backwards
+  ## compatibility.
+  #supportsAttachJSON($supportsAttachJSON)
+  #if ($supportsAttachJSON)
+    #set ($discard = $sourceParams.put('template', 'xpart.vm'))
+    #set ($discard = $sourceParams.put('vm', 'attachmentsjson.vm'))
+  #else
+    #set ($discard = $sourceParams.put('resultPage', 'Confluence.Macros.AttachmentsJSON'))
+  #end
   #getLiveDataSort($liveDataSort)
   #if ($invalidSortBy)
     {{warning}}
@@ -753,7 +766,7 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     id="$liveDataId"
     properties="mimeType,filename,filesize,date,author,actions"
     source='liveTable'
-    sourceParameters="$sourceParameters"
+    sourceParameters="$escapetool.url($sourceParams)"
     sort="$liveDataSort"
     limit=5
   }}$jsontool.serialize($liveDataConfig){{/liveData}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/AttachmentsJSON.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/AttachmentsJSON.xml
@@ -1,0 +1,356 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="Confluence.Macros.AttachmentsJSON" locale="">
+  <web>Confluence.Macros</web>
+  <name>AttachmentsJSON</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>Confluence.Macros.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>AttachmentsJSON</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity output="false"}}
+## This code was copied from attachment_macros.vm for backwards compatibility, since
+## it's needed for constructing the attachments JSON response.
+#set ($validAttachmentProperties = ['filename', 'filesize', 'mimeType', 'date', 'author', 'version'])
+
+#macro (sortAttachments $attachments $by)
+  #set ($sortAttachmentsBy = $by)
+  #if ($validAttachmentProperties.indexOf($by) &lt; 0)
+    ## Default to sorting by file name.
+    #set ($sortAttachmentsBy = 'filename')
+  #end
+  ## Set attachment sorting direction.
+  #if ($sortAttachmentsBy == 'date')
+    ## Sort the dates descending.
+    #set ($sortAttachmentsBy = 'date:desc')
+  #else
+    ## Sort everthing else ascending.
+    #set ($sortAttachmentsBy = "$sortAttachmentsBy:asc")
+  #end
+  #set ($attachments = $collectiontool.sort($attachments, $sortAttachmentsBy))
+#end
+
+#macro (filterAttachments $attachments $patterns)
+  #set ($filteredAttachments = [])
+  #foreach ($attachment in $attachments)
+    #set ($mimeType = $attachment.mimeType.toLowerCase())
+    #set ($extension = $NULL)
+    #set ($extensionIndex = $attachment.filename.lastIndexOf('.'))
+    #if ($extensionIndex &gt;= 0)
+      #set ($extension = $attachment.filename.substring($mathtool.add($extensionIndex, 1)).toLowerCase())
+    #end
+    #foreach ($pattern in $patterns)
+      #if ($pattern == $extension || $mimeType.startsWith($pattern) || $mimeType.endsWith($pattern))
+        #set ($discard = $filteredAttachments.add($attachment))
+        #break
+      #end
+    #end
+  #end
+  #set ($attachments = $filteredAttachments)
+#end
+
+#macro (maybeApplyStringFilter $fieldName $defaultMatchType $constraints $queryParameters)
+  #if ("$!request.getParameter($fieldName)" != '' &amp;&amp; $request.getParameter("${fieldName}_match") != 'empty')
+    #set ($fieldNameWithAlias = $fieldName)
+    #if ($fieldName.indexOf('.') &lt; 0)
+      #set ($fieldNameWithAlias = 'attachment.' + $fieldName)
+    #end
+    #set ($matchType = $request.getParameter("${fieldName}_match"))
+    #if ("$!matchType" == '')
+      #set ($matchType = $defaultMatchType)
+    #end
+    #set ($parameterName = $fieldNameWithAlias.replace('.', '_'))
+    #if ($matchType == 'exact')
+      #set ($discard = $constraints.add("$fieldNameWithAlias = :$parameterName"))
+      #set ($parameterValue = $request.getParameter($fieldName))
+    #else
+      #set ($discard = $constraints.add("lower($fieldNameWithAlias) like lower(:$parameterName)"))
+      #set ($parameterValue = $request.getParameter($fieldName).trim())
+    #end
+    #set ($discard = $queryParameters.add({
+      'name': $parameterName,
+      'match': $matchType,
+      'value': $parameterValue
+    }))
+  #end
+#end
+
+#macro (maybeApplyIntegerRangeFilter $fieldName $constraints $queryParameters)
+  #set ($fieldValue = $request.getParameter($fieldName))
+  #set ($matchType = $request.getParameter("${fieldName}_match"))
+  #if ("$!fieldValue" != '' &amp;&amp; $matchType != 'empty')
+    #set ($range = $fieldValue.split('-'))
+    #set ($range = [$numbertool.toNumber($range.get(0)).intValue(), $numbertool.toNumber($range.get(1)).intValue()])
+    #applyRangeFilter($fieldName $range $constraints $queryParameters)
+  #end
+#end
+
+#macro (maybeApplyDateRangeFilter $fieldName $constraints $queryParameters)
+  #set ($fieldValue = $request.getParameter($fieldName))
+  #if ("$!fieldValue" != '')
+    #set ($dateRange = {})
+    #parseDateRange('' $fieldValue $dateRange)
+    #set ($range = [$dateRange.start,$dateRange.end])
+    #applyRangeFilter($fieldName $range $constraints $queryParameters)
+  #end
+#end
+
+#macro (applyRangeFilter $fieldName $range $constraints $queryParameters)
+  #set ($fieldNameWithAlias = $fieldName)
+  #if ($fieldName.indexOf('.') &lt; 0)
+    #set ($fieldNameWithAlias = 'attachment.' + $fieldName)
+  #end
+  #set ($parameterNamePrefix = $fieldNameWithAlias.replace('.', '_'))
+  #set ($start = $range.get(0))
+  #if ($start)
+    #set ($startParameterName = $parameterNamePrefix + '_start')
+    #set ($discard = $constraints.add("$fieldNameWithAlias &gt;= :$startParameterName"))
+    #set ($discard = $queryParameters.add({
+      'name': $startParameterName,
+      'match': 'exact',
+      'value': $start
+    }))
+  #end
+  #set ($end = $range.get(1))
+  #if ($end)
+    #set ($endParameterName = $parameterNamePrefix + '_end')
+    #set ($discard = $constraints.add("$fieldNameWithAlias &lt; :$endParameterName"))
+    #set ($discard = $queryParameters.add({
+      'name': $endParameterName,
+      'match': 'exact',
+      'value': $end
+    }))
+  #end
+#end
+
+#macro (displayAttachmentMimeType $attachment)
+  &lt;div class="attachmentMimeType" data-type="$!escapetool.xml($attachment.mimeType)"&gt;
+    #if ($attachment.isImage())
+      &lt;span title="$escapetool.xml($services.localization.render('core.viewers.attachments.mime.image'))"&gt;
+        &lt;img src="$escapetool.xml($xwiki.getURL($attachment.getReference(), 'download', 'width=48'))"
+          alt="$escapetool.xml($attachment.filename)"/&gt;
+      &lt;/span&gt;
+    #else
+      #mimetypeimg($attachment.mimeType.toLowerCase() $attachment.filename.toLowerCase())
+    #end
+  &lt;/div&gt;
+#end
+
+#macro (displayFileNameAndVersion $attachmentReference $attachment)
+  &lt;span class="name"&gt;
+    &lt;a href="$escapetool.xml($xwiki.getURL($attachment.getReference()))"
+      data-entity-type="$escapetool.xml($attachmentReference.type)"
+      data-entity-reference="$escapetool.xml($services.model.serialize($attachmentReference, 'default'))"
+      title="$escapetool.xml($services.localization.render('core.viewers.attachments.download'))"
+    &gt;$escapetool.xml($attachment.filename)&lt;/a&gt;
+  &lt;/span&gt;
+  &lt;sup&gt;
+    &lt;span class="version"&gt;
+      &lt;a href="$escapetool.xml($xwiki.getURL($attachmentReference, 'viewattachrev', $NULL))"
+        title="$escapetool.xml($services.localization.render('core.viewers.attachments.showHistory'))"
+      &gt;$escapetool.xml($attachment.version)&lt;/a&gt;
+    &lt;/span&gt;
+  &lt;/sup&gt;
+#end
+
+#macro (displayUserNameWithAvatar $userName)
+  &lt;div class="user" data-reference="$escapetool.xml($userName)"&gt;
+    &lt;span class="user-avatar-wrapper"&gt;
+      #getUserAvatarURL($userName $avatarURL 120)
+      &lt;img class="user-avatar" src="$escapetool.xml($avatarURL.url)" /&gt;
+    &lt;/span&gt;
+    $xwiki.getUserName($userName)
+  &lt;/div&gt;
+#end
+
+#macro (displayAttachmentSize $longSize)
+  &lt;span class="size" data-size="$!escapetool.xml($longSize)"&gt;#dynamicsize($longSize)&lt;/span&gt;
+#end
+
+#macro (displayAttachmentActions $attachment)
+  &lt;div class="attachmentActions"&gt;
+    #if ($services.officemanager.isConnected() &amp;&amp;
+        $services.officeviewer.isMimeTypeSupported($attachment.mimeType.toLowerCase()))
+      ## Link to preview office document.
+      &lt;a class="viewlink action" title="$escapetool.xml($services.localization.render(
+        'core.viewers.attachments.officeView.title'))" target="_blank"
+        href="$escapetool.xml($attachment.document.getURL('view', $escapetool.url({
+          'xpage': 'office',
+          'attachment': $attachment.filename
+        })))"&gt;
+          &lt;span class="action-icon"&gt;$services.icon.renderHTML('eye')&lt;/span&gt;&lt;span class="action-label"&gt;$escapetool.xml(
+            $services.localization.render('core.viewers.attachments.officeView'))
+          &lt;/span&gt;
+        &lt;/a&gt;
+    #end
+    #if ($hasEdit || $hasAdmin)
+      #set ($queryString = $escapetool.url({
+        'xpage': 'attachment/move',
+        'attachment': $services.model.serialize($attachment.getReference(), 'default')
+      }))
+      #set ($moveURL = $xwiki.getURL($attachment.document.documentReference, 'view', $queryString))
+      &lt;a class="move-attachment action" title="$escapetool.xml($services.localization.render(
+          'core.viewers.attachments.move.title'))" href="$escapetool.xml($moveURL#)"&gt;
+        &lt;span class="action-icon"&gt;$services.icon.renderHTML('edit')&lt;/span&gt;&lt;span class="action-label"&gt;$escapetool.xml(
+          $services.localization.render('core.viewers.attachments.move'))
+        &lt;/span&gt;
+      &lt;/a&gt;
+    #end
+    #if ($hasEdit || $hasAdmin)
+      ## Delete attachment link.
+      ## If a remote URL is provided, content will be loaded into .modal-content because of bootstrap.
+      ## By providing an anchor this behavior is stopped, without altering the URL functionality.
+      #set ($queryString = $escapetool.url({
+        'form_token': $services.csrf.token,
+        'xredirect': $options.redirect
+      }))
+      #set ($deleteURL = $xwiki.getURL($attachment.getReference(), 'delattachment', $queryString))
+      &lt;a class="actiondelete action" title="$escapetool.xml($services.localization.render(
+          'core.viewers.attachments.delete.title', [$attachment.filename]))" href="$escapetool.xml($deleteURL)"&gt;
+        &lt;span class="action-icon"&gt;$services.icon.renderHTML('cross')&lt;/span&gt;&lt;span class="action-label"&gt;$escapetool.xml(
+          $services.localization.render('core.viewers.attachments.delete'))
+        &lt;/span&gt;
+      &lt;/a&gt;
+    #end
+    #foreach($uix in $services.uix.getExtensions('org.xwiki.platform.attachment.actions'))
+      $services.rendering.render($uix.execute(), 'html/5.0')
+    #end
+  &lt;/div&gt;
+#end
+{{/velocity}}
+
+{{velocity}}
+## This page should be deleted after upgrading the parent to a version of XWiki &gt;= 14.10.
+## The code was copied from attachmentsjson.vm for backwards compatibility, since it wasn't
+## present on the minimal supported version 13.10.
+#template('hierarchy_macros.vm')
+#if ($xcontext.action == 'get')
+  #set ($offset = $numbertool.toNumber($request.offset).intValue())
+  ## The offset sent by the live table starts at 1.
+  #set ($offset = $offset - 1)
+  #if (!$offset || $offset &lt; 0)
+    #set ($offset = 0)
+  #end
+  #set ($limit = $numbertool.toNumber($request.limit).intValue())
+  #if (!$limit)
+    #set ($limit = 15)
+  #end
+  ##
+  ## Apply live table filters.
+  ##
+  #set ($constraints = ['attachment.docId = doc.id', 'doc.id = :docId'])
+  #set ($queryParameters = [{
+    'name': 'docId',
+    'match': 'exact',
+    'value': $doc.getId()
+  }])
+  #maybeApplyStringFilter('mimeType' 'prefix' $constraints $queryParameters)
+  #maybeApplyStringFilter('filename' 'partial' $constraints $queryParameters)
+  #maybeApplyIntegerRangeFilter('filesize' $constraints $queryParameters)
+  #maybeApplyDateRangeFilter('date' $constraints $queryParameters)
+  #maybeApplyStringFilter('author' 'partial' $constraints $queryParameters)
+  #set ($whereClause = '')
+  #if ($constraints.size() &gt; 0)
+    #set ($whereClause = 'where ' + $stringtool.join($constraints, ' and '))
+  #end
+  ##
+  ## Determine the sort field and direction.
+  ##
+  #set ($validSortFields = ['mimeType', 'filename', 'doc.fullName', 'filesize', 'date', 'author'])
+  #set ($sortField = $request.sort)
+  #if (!$validSortFields.contains($sortField))
+    #set ($sortField = 'filename')
+  #end
+  #set ($caseInsensitiveSort = $sortField != 'date' &amp;&amp; $sortField != 'filesize')
+  #if (!$sortField.startsWith('doc.'))
+    #set ($sortField = "attachment.$sortField")
+  #end
+  #set ($direction = 'asc')
+  #if ("$!request.dir" == 'desc')
+    #set ($direction = 'desc')
+  #end
+  #if ($caseInsensitiveSort)
+    #set ($orderByClause = "order by lower($sortField) $direction, $sortField $direction")
+  #else
+    #set ($orderByClause = "order by $sortField $direction")
+  #end
+  ##
+  ## Compute the final query.
+  ##
+  #set ($query =  $services.query.hql("$whereClause $orderByClause"))
+  #set ($discard = $query.addFilter('attachment'))
+  #set ($discard = $query.setLimit($limit).setOffset($offset))
+  #foreach ($queryParameter in $queryParameters)
+    #if ($queryParameter.match == 'exact')
+      #set ($discard = $query.bindValue($queryParameter.name, $queryParameter.value))
+    #elseif ($queryParameter.match == 'prefix')
+      #set ($query = $query.bindValue($queryParameter.name).literal($queryParameter.value).anyChars().query())
+    #else
+      ## Partial match.
+      #set ($query = $query.bindValue($queryParameter.name).anyChars().literal($queryParameter.value).anyChars().query())
+    #end
+  #end
+  #set ($attachmentsReferences = $query.execute())
+  #set ($queryString = $escapetool.url({
+    'form_token': $services.csrf.token,
+    'xredirect': "$doc.getURL()#Attachments"
+  }))
+  #set ($results = {
+    "totalrows": $query.count(),
+    "returnedrows": $mathtool.min($attachmentsReferences.size(), $limit),
+    "offset": $mathtool.add($offset, 1),
+    "reqNo": $numbertool.toNumber($request.reqNo).intValue(),
+    "rows": []
+  })
+  #foreach ($attachmentReference in $attachmentsReferences)
+    #set ($hasAccess = $services.security.authorization.hasAccess('view', $attachmentReference))
+    #set ($row = {
+      'doc_viewable': $hasAccess
+    })
+    #if ($hasAccess)
+      #set ($attachment = $doc.getAttachment($attachmentReference.name))
+      #set ($authorReference = $services.model.resolveDocument($attachment.author))
+      #set ($discard = $row.putAll({
+        'id': $attachment.filename,
+        'filename': "#displayFileNameAndVersion($attachmentReference $attachment)",
+        'mimeType': "#displayAttachmentMimeType($attachment)",
+        'filesize': "#displayAttachmentSize($attachment.longSize)",
+        'date': $xwiki.formatDate($attachment.date),
+        'author': "#displayUserNameWithAvatar($attachment.author)",
+        'actions': "#displayAttachmentActions($attachment)"
+      }))
+    #end
+    #set ($discard = $results.rows.add($row))
+  #end
+  #jsonResponse($results)
+#end
+{{/velocity}}</content>
+</xwikidoc>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/AttachmentsJSON.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/AttachmentsJSON.xml
@@ -248,9 +248,8 @@
 {{/velocity}}
 
 {{velocity}}
-## This page should be deleted after upgrading the parent to a version of XWiki &gt;= 14.10.
-## The code was copied from attachmentsjson.vm for backwards compatibility, since it wasn't
-## present on the minimal supported version 13.10.
+## This page should be deleted after upgrading the parent to a version of XWiki &gt;= 14.8. The code was copied from
+## attachmentsjson.vm for backwards compatibility, since it wasn't present on the minimal supported version 13.10.
 #template('hierarchy_macros.vm')
 #if ($xcontext.action == 'get')
   #set ($offset = $numbertool.toNumber($request.offset).intValue())

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
@@ -59,6 +59,8 @@ rendering.macro.section.parameter.border.description=Select this option to draw 
 
 ## Attachments macro
 promacros.attachments.upload.title=Upload files to the associated page
+## This should be removed after upgrading the XWiki parent to a version &gt;= 14.10.
+core.viewers.attachments.move=Move
 
 ## Column macro
 rendering.macro.column.name=Column Macro

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
@@ -59,7 +59,7 @@ rendering.macro.section.parameter.border.description=Select this option to draw 
 
 ## Attachments macro
 promacros.attachments.upload.title=Upload files to the associated page
-## This should be removed after upgrading the XWiki parent to a version &gt;= 14.10.
+## This should be removed after upgrading the XWiki parent to a version &gt;= 14.6.
 core.viewers.attachments.move=Move
 
 ## Column macro


### PR DESCRIPTION
* copy the attachmentsjson.vm and attachment_macros.vm code to this macro, since the (complete) code is not present on XWiki < 14.8; this page is used only if the 2 mentioned vms are not present / do not have the correct version;
* added the move button translation + some css, since it's missing in versions before 14.6
* before 14.4, we also didn't had access to a liveData object from JS, in order to refresh the entries when needed, so the complete page is refreshed on those cases
* fix bug for upload fields, which weren't working after coming from the edit action

In short, this PR will make the attachments livedata to work on versions before 14.8. The only limitation is the upload and deleted actions will trigger a page reload, instead of a livedata reload (this only before 14.4)