### PR TITLE
Some macros are not working on XWiki 15.5 and higher #180

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
@@ -102,7 +102,7 @@
     ##
     ## Check if the diagram page exists
     #set($docReferenceSerialized = $services.model.serialize($doc.documentReference, 'local'))
-    #set($diagrams = $services.query.xwql('from doc.object(Confluence.Macros.DiagramClass) as diagramObj where diagramObj.page = :page and diagramObj.diagramName = :diagramName').bindValue('page', $docReferenceSerialized).bindValue('diagramName', $diagramName).setLimit(1).execute())
+    #set($diagrams = $services.query.xwql('from doc.object(Confluence.Macros.DiagramClass) as diagramObj where diagramObj.page = :page and diagramObj.diagramName = :diagramName').bindValue('page', $docReferenceSerialized).bindValue('diagramName', "$!diagramName").setLimit(1).execute())
     #if($diagrams.size() &gt; 0)
       #set($diagram = $diagrams.get(0))
     #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
@@ -298,6 +298,11 @@ The result is the following:
 ## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #if ("$!xcontext.macro.params.diagramname" != '')
+    {{warning}}
+      $services.localization.render('xwikipro.macro.empty', 'drawio', 'diagramname')
+    {{/warning}}
+  #end
   #displayConfluenceDiagram()
 #else
   {{error}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Drawio.xml
@@ -298,11 +298,6 @@ The result is the following:
 ## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
-  #if ("$!xcontext.macro.params.diagramname" != '')
-    {{warning}}
-      $services.localization.render('xwikipro.macro.empty', 'drawio', 'diagramname')
-    {{/warning}}
-  #end
   #displayConfluenceDiagram()
 #else
   {{error}}
@@ -411,7 +406,7 @@ The result is the following:
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>diagramName</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
@@ -411,7 +411,7 @@ The result is the following:
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>name</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
@@ -298,11 +298,6 @@ The result is the following:
 ## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
-  #if ("$!xcontext.macro.params.name" != '')
-    {{warning}}
-      $services.localization.render('xwikipro.macro.empty', 'gliffy', 'name')
-    {{/warning}}
-  #end
   #displayConfluenceDiagram()
 #else
   {{error}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Gliffy.xml
@@ -298,6 +298,11 @@ The result is the following:
 ## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #if ("$!xcontext.macro.params.name" != '')
+    {{warning}}
+      $services.localization.render('xwikipro.macro.empty', 'gliffy', 'name')
+    {{/warning}}
+  #end
   #displayConfluenceDiagram()
 #else
   {{error}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/MicrosoftStream.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/MicrosoftStream.xml
@@ -393,7 +393,7 @@ $xwiki.currentContentSyntaxId)|No|false
       <description>The URL to the Microsoft Stream video.</description>
     </property>
     <property>
-      <mandatory>0</mandatory>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>uri</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
@@ -423,7 +423,7 @@ class Simple{
       )))
     #end
     {{code language="$services.rendering.escape("$!language", $xwiki.currentContentSyntaxId)"}}
-      "$!wikimacro.content"
+      $!wikimacro.content
     {{/code}}
   )))
 #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/PasteCode.xml
@@ -423,7 +423,7 @@ class Simple{
       )))
     #end
     {{code language="$services.rendering.escape("$!language", $xwiki.currentContentSyntaxId)"}}
-      $wikimacro.content
+      "$!wikimacro.content"
     {{/code}}
   )))
 #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Time.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Time.xml
@@ -268,8 +268,14 @@ The Time Confluence bridge macro show the time given in its datetime parameter.
 ## on the macro definition page. See XWIKI-14828: Rendering macros defined in wiki pages are available to users that
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
+  #set ($datetime = $escapetool.xml($!wikimacro.parameters.datetime))
+  #if ("!datetime" == '')
+    {{warning}}
+      $services.localization.render('xwikipro.macro.empty', 'time', 'datetime')
+    {{warning}}
+  #end
   {{html clean=false}}
-    &lt;time datetime="$escapetool.xml($wikimacro.parameters.datetime)"&gt;$escapetool.xml($wikimacro.parameters.datetime)&lt;/time&gt;
+    &lt;time datetime="$datetime"&gt;$datetime&lt;/time&gt;
   {{/html}}
 #else
   {{error}}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Time.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Time.xml
@@ -269,13 +269,9 @@ The Time Confluence bridge macro show the time given in its datetime parameter.
 ## don't have view right on those pages.
 #if ($services.licensing.licensor.hasLicensureForEntity($xcontext.macro.doc.documentReference))
   #set ($datetime = $escapetool.xml($!wikimacro.parameters.datetime))
-  #if ("!datetime" == '')
-    {{warning}}
-      $services.localization.render('xwikipro.macro.empty', 'time', 'datetime')
-    {{warning}}
   #end
   {{html clean=false}}
-    &lt;time datetime="$datetime"&gt;$datetime&lt;/time&gt;
+    &lt;time datetime="$!datetime"&gt;$!datetime&lt;/time&gt;
   {{/html}}
 #else
   {{error}}
@@ -313,6 +309,84 @@ The Time Confluence bridge macro show the time given in its datetime parameter.
     </property>
     <property>
       <visibility>Current Wiki</visibility>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Time Macro</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>6cd47d70-88dc-43fc-8ab1-dfd971fefb44</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description/>
+    </property>
+    <property>
+      <mandatory>1</mandatory>
+    </property>
+    <property>
+      <name>datetime</name>
+    </property>
+    <property>
+      <type/>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Translations.xml
@@ -36,7 +36,10 @@
   <minorEdit>false</minorEdit>
   <syntaxId>plain/1.0</syntaxId>
   <hidden>true</hidden>
-  <content>confluencediagram.installRequired=In order to use this macro, the Diagram application needs to be installed. To install, {0}click here{1}.
+  <content>## General
+xwikipro.macro.empty=Empty [{0}] macro. Please specify the [{1}] parameter.
+
+confluencediagram.installRequired=In order to use this macro, the Diagram application needs to be installed. To install, {0}click here{1}.
 confluencediagram.create=The above image is a preview of a diagram created in Confluence. If you want to modify it, click on the button below to convert it into an editable diagram. You can always go back to this preview.
 confluencediagram.create.confirm=Convert
 confluencediagram.create.success=The diagram has been converted.

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -399,7 +399,7 @@
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>att--filename</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewdoc.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewdoc.xml
@@ -380,7 +380,7 @@
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>att--filename</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewpdf.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewpdf.xml
@@ -368,7 +368,7 @@
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>att--filename</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewppt.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewppt.xml
@@ -380,7 +380,7 @@
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>att--filename</name>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewxls.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Viewxls.xml
@@ -380,7 +380,7 @@
       <description/>
     </property>
     <property>
-      <mandatory/>
+      <mandatory>1</mandatory>
     </property>
     <property>
       <name>att--filename</name>


### PR DESCRIPTION
The faulty macros I found were the following:

![badmacros](https://github.com/xwikisas/xwiki-pro-macros/assets/45433221/b8efb61c-7356-4c3b-8602-4b98b2c11be4)

To fix most of the issues, I made the parameters mandatory.

