### PR TITLE
Excerpt-Include macro does not create backlinks on migration #199

### DIFF
--- a/xwiki-pro-macros-api/pom.xml
+++ b/xwiki-pro-macros-api/pom.xml
@@ -90,5 +90,10 @@
       <artifactId>xwiki-rendering-macro-box</artifactId>
       <version>${rendering.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-rendering-macro-include</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/AbstractExcerptIncludeRunnable.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/AbstractExcerptIncludeRunnable.java
@@ -1,0 +1,86 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.util.AbstractXWikiRunnable;
+
+/**
+ * Base class for excerpt Runnable. It provides tools for working with excerptsQueue.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Unstable
+public abstract class AbstractExcerptIncludeRunnable extends AbstractXWikiRunnable
+{
+    /**
+     * Stop runnable entry.
+     */
+    public static final ExcerptQueueEntry STOP_RUNNABLE_ENTRY = new ExcerptQueueEntry(null, null);
+
+    /**
+     * Entries to be processed by this thread.
+     */
+    private final BlockingQueue<ExcerptQueueEntry> excerptsQueue = new LinkedBlockingQueue<>();
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Add entries to the thread's queue.
+     *
+     * @param queueEntry the entry to be added
+     */
+    public void addToQueue(ExcerptQueueEntry queueEntry)
+    {
+        this.excerptsQueue.add(queueEntry);
+    }
+
+    /**
+     * Process new excerpt entry of queue.
+     *
+     * @return queueEntry the new excerpt entry
+     */
+    public ExcerptQueueEntry getNextExcerptQueueEntry()
+    {
+        ExcerptQueueEntry queueEntry;
+
+        try {
+            queueEntry = this.excerptsQueue.take();
+        } catch (InterruptedException e) {
+            logger.warn("Excerpts update thread has been interrupted", e);
+            queueEntry = STOP_RUNNABLE_ENTRY;
+        }
+
+        if (queueEntry == STOP_RUNNABLE_ENTRY) {
+            this.excerptsQueue.clear();
+        }
+
+        return queueEntry;
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptIncludeMacroRefactoring.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptIncludeMacroRefactoring.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.internal.macro.include.IncludeMacroRefactoring;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.macro.MacroRefactoringException;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Implementation of reference refactoring operation for excerpt-include macro "0" parameter.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Component
+@Singleton
+@Named("excerpt-include")
+@Unstable
+public class ExcerptIncludeMacroRefactoring extends IncludeMacroRefactoring
+{
+    @Override
+    public Set<ResourceReference> extractReferences(MacroBlock macroBlock) throws MacroRefactoringException
+    {
+        Map<String, String> parameters = new HashMap<>(macroBlock.getParameters());
+        parameters.put("reference", parameters.remove("0"));
+        macroBlock.setParameters(parameters);
+        return super.extractReferences(macroBlock);
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptIncludeMacroRunnable.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptIncludeMacroRunnable.java
@@ -1,0 +1,136 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Updates the excerpt-include macro reference parameter after the rename of an excerpt page.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Component(roles = ExcerptIncludeMacroRunnable.class)
+@Singleton
+@Unstable
+public class ExcerptIncludeMacroRunnable extends AbstractExcerptIncludeRunnable
+{
+    private static final String MACRO_REFERENCE_PARAMETER = "0";
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    @Named("compact")
+    private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * @see com.xpn.xwiki.util.AbstractXWikiRunnable#runInternal()
+     */
+    @Override
+    public void runInternal()
+    {
+        while (!Thread.interrupted()) {
+            ExcerptQueueEntry queueEntry = getNextExcerptQueueEntry();
+
+            if (queueEntry == STOP_RUNNABLE_ENTRY) {
+                break;
+            }
+
+            XWikiContext xcontext = contextProvider.get();
+            DocumentReference originalDocRef = queueEntry.originalDocRef;
+            DocumentReference currentDocRef = queueEntry.currentDocRef;
+
+            try {
+                // We need to take backlinks from the original document because at this step they are not loaded on
+                // the new document.
+                List<DocumentReference> backlinks =
+                    xcontext.getWiki().getDocument(originalDocRef, xcontext).getBackLinkedReferences(xcontext);
+
+                for (DocumentReference backlinkDocRef : backlinks) {
+                    XWikiDocument backlinkDoc = xcontext.getWiki().getDocument(backlinkDocRef, xcontext);
+
+                    updateExcerptIncludeMacrosReferences(backlinkDoc, currentDocRef, originalDocRef, xcontext);
+                }
+            } catch (XWikiException e) {
+                logger.warn("Update excerpt include macro reference parameter thread interrupted", e);
+            }
+        }
+    }
+
+    /**
+     * Update a page excerpt include macro's old reference with the new one.
+     *
+     * @param document document that need to be updated with the new reference
+     * @param newReference new excerpt reference
+     * @param oldReference old excerpt reference
+     * @param xcontext the XWikiContext
+     * @throws XWikiException if updating the document fails
+     */
+    public void updateExcerptIncludeMacrosReferences(XWikiDocument document, DocumentReference newReference,
+        DocumentReference oldReference, XWikiContext xcontext) throws XWikiException
+    {
+        XDOM backlinkDocXDOM = document.getXDOM();
+        List<Block> macroBlocks = backlinkDocXDOM.getBlocks(new MacroBlockMatcher("excerpt-include"), Block.Axes.CHILD);
+
+        String newReferenceString =
+            compactEntityReferenceSerializer.serialize(newReference, document.getDocumentReference());
+        String oldReferenceString =
+            compactEntityReferenceSerializer.serialize(oldReference, document.getDocumentReference());
+
+        boolean modified = false;
+        for (Block macroBlock : macroBlocks) {
+            String macroReference = macroBlock.getParameter(MACRO_REFERENCE_PARAMETER);
+
+            if (!macroReference.equals(newReferenceString) && macroReference.equals(oldReferenceString)) {
+                macroBlock.setParameter(MACRO_REFERENCE_PARAMETER, newReferenceString);
+                modified = true;
+            }
+        }
+
+        if (modified) {
+            document.setContent(backlinkDocXDOM);
+            xcontext.getWiki().saveDocument(document, "Updated excerpt-include macros references after excerpt page "
+                    + "rename",
+                xcontext);
+        }
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptQueueEntry.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/ExcerptQueueEntry.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal;
+
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Excerpt Queue Entry.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Unstable
+public class ExcerptQueueEntry
+{
+    /**
+     * Reference to the page before rename operation.
+     */
+    public DocumentReference originalDocRef;
+
+    /**
+     * Reference to the page after rename operation.
+     */
+    public DocumentReference currentDocRef;
+
+    /**
+     * Constructor.
+     *
+     * @param originalDocRef document reference before rename
+     * @param currentDocRef document reference after rename
+     */
+    public ExcerptQueueEntry(DocumentReference originalDocRef, DocumentReference currentDocRef)
+    {
+        this.originalDocRef = originalDocRef;
+        this.currentDocRef = currentDocRef;
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/StoreHandler.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/StoreHandler.java
@@ -1,0 +1,142 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.hibernate.Query;
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.doc.XWikiLink;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
+import com.xpn.xwiki.store.XWikiHibernateStore;
+import com.xpn.xwiki.store.XWikiStoreInterface;
+
+/**
+ * Handler for XWikiStore operations.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Component(roles = StoreHandler.class)
+@Singleton
+@Unstable
+public class StoreHandler
+{
+    @Inject
+    @Named("local")
+    private EntityReferenceSerializer<String> localEntityReferenceSerializer;
+
+    @Inject
+    @Named("compactwiki")
+    private EntityReferenceSerializer<String> compactwikiEntityReferenceSerializer;
+
+    @Inject
+    @Named("hibernate")
+    private Provider<XWikiStoreInterface> hibernateStoreProvider;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Add a backlink between 2 documents.
+     *
+     * @param session the Hibernate Session
+     * @param document document that contains a reference to another document
+     * @param linkedDocRef reference of the linked document
+     * @param context the context in which the code is executed.
+     */
+    public void addXWikiLink(Session session, XWikiDocument document, DocumentReference linkedDocRef,
+        XWikiContext context)
+    {
+        XWikiLink wikiLink = new XWikiLink();
+        String serializedParentDocRef = localEntityReferenceSerializer.serialize(document.getDocumentReference());
+        String serializedLinkedDocRef = compactwikiEntityReferenceSerializer.serialize(linkedDocRef);
+
+        wikiLink.setDocId(document.getId());
+        wikiLink.setFullName(serializedParentDocRef);
+        wikiLink.setLink(serializedLinkedDocRef);
+
+        try {
+            if (StringUtils.length(wikiLink.getLink()) > getStore().getLimitSize(context, XWikiLink.class, "link")) {
+                logger.warn("Failed to add a backlink to [{}] since [{}] exceeds the 253 characters limit",
+                    serializedParentDocRef, serializedLinkedDocRef);
+            } else {
+                session.saveOrUpdate(wikiLink);
+            }
+        } catch (ComponentLookupException e) {
+            logger.warn("Failed to add a backlink to [{}]. Cause [{}].", serializedParentDocRef,
+                ExceptionUtils.getRootCauseMessage(e));
+        }
+    }
+
+    /**
+     * Delete backlinks from this document.
+     *
+     * @param docId the id of the document
+     * @param context the current request context
+     * @throws XWikiException fail during delete action
+     */
+    public void deleteLinks(long docId, XWikiContext context) throws XWikiException
+    {
+        try {
+            getStore().executeWrite(context, new HibernateCallback<Object>()
+            {
+                @Override
+                public Object doInHibernate(Session session) throws XWikiException
+                {
+                    Query query = session.createQuery("delete from XWikiLink as link where link.id.docId = :docId");
+                    query.setParameter("docId", docId);
+                    query.executeUpdate();
+
+                    return Boolean.TRUE;
+                }
+            });
+        } catch (Exception e) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
+                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_DELETING_LINKS, "Exception while deleting links", e);
+        }
+    }
+
+    /**
+     * Get instance of XWikiHibernateStore.
+     *
+     * @return store system for execute store-specific actions.
+     * @throws ComponentLookupException if the store could not be reached
+     */
+    public XWikiHibernateStore getStore() throws ComponentLookupException
+    {
+        return (XWikiHibernateStore) hibernateStoreProvider.get();
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/listener/ExcerptIncludeMacroListener.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/listener/ExcerptIncludeMacroListener.java
@@ -1,0 +1,119 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal.listener;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.xwiki.bridge.event.DocumentCreatedEvent;
+import org.xwiki.bridge.event.DocumentDeletedEvent;
+import org.xwiki.bridge.event.DocumentUpdatedEvent;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore.HibernateCallback;
+import com.xwiki.macros.excerptinclude.internal.StoreHandler;
+
+/**
+ * Listens to created, updated or deleted pages, checks for Excerpt Include Macro and adds/removes backlinks for the
+ * excerpt macro page referenced in the excerpt-include macro. The backlinks are used to update the "0" parameter of the
+ * excerpt-include macro in case of excerpt page rename.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Component
+@Named(ExcerptIncludeMacroListener.ROLE_HINT)
+@Singleton
+@Unstable
+public class ExcerptIncludeMacroListener extends AbstractEventListener
+{
+    protected static final String ROLE_HINT = "ExcerptIncludeMacroListener";
+
+    @Inject
+    @Named("explicit")
+    private DocumentReferenceResolver<String> explicitDocumentReferenceResolver;
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private StoreHandler storeHandler;
+
+    /**
+     * Constructor.
+     */
+    public ExcerptIncludeMacroListener()
+    {
+        super(ROLE_HINT, Arrays.<Event>asList(new DocumentCreatedEvent(), new DocumentDeletedEvent(),
+            new DocumentUpdatedEvent()));
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        XWikiDocument document = (XWikiDocument) source;
+        XWikiContext context = (XWikiContext) data;
+
+        List<Block> macroBlocks =
+            document.getXDOM().getBlocks(new MacroBlockMatcher("excerpt-include"), Block.Axes.CHILD);
+
+        if (!macroBlocks.isEmpty()) {
+            try {
+                // We need to delete existing links before saving the page's ones.
+                storeHandler.deleteLinks(document.getId(), context);
+                storeHandler.getStore().executeWrite(context, new HibernateCallback<Object>()
+                {
+                    @Override
+                    public Object doInHibernate(Session session) throws XWikiException
+                    {
+                        // Is necessary to blank links from doc.
+                        context.remove("links");
+
+                        for (Block macroBlock : macroBlocks) {
+                            DocumentReference excerptReference = explicitDocumentReferenceResolver
+                                .resolve(macroBlock.getParameter("0"), document.getDocumentReference());
+                            storeHandler.addXWikiLink(session, document, excerptReference, context);
+                        }
+
+                        return Boolean.TRUE;
+                    }
+                });
+            } catch (Exception e) {
+                logger.warn("Failed to update backlinks of excerpt macro", e);
+            }
+        }
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/listener/PageRenameListener.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/excerptinclude/internal/listener/PageRenameListener.java
@@ -1,0 +1,189 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.excerptinclude.internal.listener;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.bridge.event.DocumentCreatedEvent;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Disposable;
+import org.xwiki.job.Job;
+import org.xwiki.job.JobContext;
+import org.xwiki.job.event.JobStartedEvent;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.ObservationContext;
+import org.xwiki.observation.event.Event;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.block.match.MacroBlockMatcher;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xwiki.macros.excerptinclude.internal.AbstractExcerptIncludeRunnable;
+import com.xwiki.macros.excerptinclude.internal.ExcerptIncludeMacroRunnable;
+import com.xwiki.macros.excerptinclude.internal.ExcerptQueueEntry;
+
+/**
+ * Listens to rename of pages and starts a thread for updating references of the excerpt-include macro.
+ *
+ * @version $Id$
+ * @since 1.14.4
+ */
+@Component
+@Named(PageRenameListener.ROLE_HINT)
+@Singleton
+@Unstable
+public class PageRenameListener extends AbstractEventListener implements Disposable
+{
+    /**
+     * The role hint of the document.
+     */
+    protected static final String ROLE_HINT = "PageRenameEventListener";
+
+    /**
+     * Thread that will handle updating the reference of an excerpt-include macro after an excerpt rename.
+     */
+    private Thread excerptMacroThread;
+
+    @Inject
+    private ObservationContext observationContext;
+
+    @Inject
+    private JobContext jobContext;
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private ExcerptIncludeMacroRunnable excerptIncludeMacroRunnable;
+
+    /**
+     * Constructor.
+     */
+    public PageRenameListener()
+    {
+        super(ROLE_HINT, new DocumentCreatedEvent());
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        if (this.excerptMacroThread == null) {
+            startThreads();
+        }
+
+        if (observationContext.isIn(new JobStartedEvent("refactoring/rename"))) {
+            XWikiDocument currentDoc = (XWikiDocument) source;
+            XDOM backlinkDocXDOM = currentDoc.getXDOM();
+            List<Block> excerptMacroBlocks = backlinkDocXDOM.getBlocks(new MacroBlockMatcher("excerpt"),
+                Block.Axes.CHILD);
+            if (excerptMacroBlocks.isEmpty()) {
+                return;
+            }
+
+            Job job = jobContext.getCurrentJob();
+            DocumentReference destinationRef = job.getRequest().getProperty("destination");
+            List<DocumentReference> references = job.getRequest().getProperty("entityReferences");
+            if (references != null && !references.isEmpty()) {
+                DocumentReference originalDocRef = references.get(0);
+                DocumentReference currentDocRef = currentDoc.getDocumentReference();
+
+                if (destinationRef.equals(currentDocRef)) {
+                    startContentUpdating(currentDoc, originalDocRef);
+                }
+            }
+        }
+    }
+
+    /**
+     * Add entries in the queue of threads that update reference parameter of excerpt-include macro after renaming an
+     * excerpt.
+     *
+     * @param currentDoc current document
+     * @param originalDocRef the reference of the document before rename
+     */
+    public void startContentUpdating(XWikiDocument currentDoc, DocumentReference originalDocRef)
+    {
+        ExcerptQueueEntry queueEntry = new ExcerptQueueEntry(originalDocRef, currentDoc.getDocumentReference());
+        this.excerptIncludeMacroRunnable.addToQueue(queueEntry);
+    }
+
+    /**
+     * Multiple rename jobs could be started at very close dates at the moment when the threads were not initialized yet
+     * (for example, at installation step) and we need to be sure that only a single instance of each thread is
+     * created.
+     */
+    public synchronized void startThreads()
+    {
+        if (this.excerptMacroThread == null) {
+            this.excerptMacroThread =
+                startThread(this.excerptIncludeMacroRunnable, "Update Excerpt Include Macro Thread");
+        }
+    }
+
+    /**
+     * Actions for starting a thread.
+     *
+     * @param excerptIncludeRunnable runnable object that implements the run method
+     * @param threadName name of the thread
+     * @return thread that was started
+     */
+    public Thread startThread(AbstractExcerptIncludeRunnable excerptIncludeRunnable, String threadName)
+    {
+        Thread excerptThread = new Thread(excerptIncludeRunnable);
+        excerptThread.setName(threadName);
+        excerptThread.setDaemon(true);
+        excerptThread.start();
+
+        return excerptThread;
+    }
+
+    /**
+     * Actions for closing a thread.
+     *
+     * @param excerptThread thread to be stopped
+     * @param excerptIncludeRunnable runnable object of the thread
+     * @throws InterruptedException if any thread has interrupted the current thread
+     */
+    public void stopThread(Thread excerptThread, AbstractExcerptIncludeRunnable excerptIncludeRunnable)
+        throws InterruptedException
+    {
+        if (excerptThread != null) {
+            excerptIncludeRunnable.addToQueue(AbstractExcerptIncludeRunnable.STOP_RUNNABLE_ENTRY);
+            excerptThread.join();
+        }
+    }
+
+    @Override
+    public void dispose()
+    {
+        try {
+            stopThread(this.excerptMacroThread, this.excerptIncludeMacroRunnable);
+        } catch (InterruptedException e) {
+            logger.warn("Excerpt backlinks update thread interrupted", e);
+        }
+    }
+}

--- a/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
@@ -5,3 +5,8 @@ com.xwiki.macros.userlist.internal.macro.UserListMacro
 com.xwiki.macros.userlist.internal.macro.UserReferenceListConverter
 com.xwiki.macros.userlist.internal.macro.GroupReferenceListConverter
 com.xwiki.macros.excerptinclude.internal.macro.ExcerptIncludeMacro
+com.xwiki.macros.excerptinclude.internal.listener.ExcerptIncludeMacroListener
+com.xwiki.macros.excerptinclude.internal.ExcerptIncludeMacroRunnable
+com.xwiki.macros.excerptinclude.internal.ExcerptIncludeMacroRefactoring
+com.xwiki.macros.excerptinclude.internal.listener.PageRenameListener
+com.xwiki.macros.excerptinclude.internal.StoreHandler


### PR DESCRIPTION
Excerpt-Include macro reference is not properly resolved at import #200
* add a refactoring component to compute the correct reference in the excerpt-include 0 parameter -> A refactoring java class is needed to trigger the whole process done for Include and Display macros
* add a listener to watch when a page that has Excerpt macro is renamed to update the references in all the Excerpt-Include macro pages
* add a listener to watch when a page that has Excerpt-Include macro is renamed to update backlink on the included Excerpt page