### PR TITLE
 Column width parameter is not respected #207 

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
@@ -209,7 +209,6 @@ Content in the column 4
     </property>
     <property>
       <code>.macro-column {
-  display: table-cell;
   padding: 5px;
 }</code>
     </property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
@@ -241,6 +241,9 @@ Content in the column 4
     <property>
       <code>.hasBorder .macro-column {
   border: 1px dashed grey;
+}
+.macro-section {
+  display:flex;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
The problem primarily arises because the macro-column CSS class has its display property set to table-cell, which behaves similarly to the <td> tag which attempts to evenly distribute the space. Through my experiments, I discovered a solution that involves modifying the {{section}} macro to set its display property to flex and to remove the display property from the column-macro. This approach seems to resolve the issue. I've also explored other solutions, such as setting the column-macro's display property to inline-block and experimenting with pseudoclasses, but each introduced additional issues. 
![image](https://github.com/xwikisas/xwiki-pro-macros/assets/92780090/f2f13554-7f90-4e30-8f56-5e59cfb12efc)
![image-1](https://github.com/xwikisas/xwiki-pro-macros/assets/92780090/8dd2398b-ca05-432d-be25-d0714d000a46)
