### PR TITLE
The panel macro cuts off content that is too wide #213

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
@@ -212,7 +212,7 @@ This macro supports all Atlassian Confluence parameters as of version 7.9.</cont
 }
 .macro-border {
   margin-bottom: 10px;
-  overflow: scroll;
+  overflow: auto;
 }</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
@@ -212,7 +212,7 @@ This macro supports all Atlassian Confluence parameters as of version 7.9.</cont
 }
 .macro-border {
   margin-bottom: 10px;
-  overflow: hidden;
+  overflow: scroll;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
Changed the the overflow property from hidden to scroll.
![image](https://github.com/xwikisas/xwiki-pro-macros/assets/92780090/d9a7a9f7-61d5-4181-be7e-f3e924fd119f)
