### PR TITLE
 Columns don't provide a WYSIWYG experience in edit mode #208 

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Column.xml
@@ -437,7 +437,7 @@ Content in the column 4
   #if ("$!xcontext.macro.params.width" != '')
     #set ($style = "style='width: $xcontext.macro.params.width'")
   #end
-  (% class="macro-column" $style %)(((
+  (% class="macro-column" data-width="$xcontext.macro.params.width" $style %)(((
     {{wikimacrocontent /}}
   )))
 #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
@@ -241,6 +241,19 @@ Content in the column 4
     <property>
       <code>.hasBorder .macro-column {
   border: 1px dashed grey;
+}
+.macro-section
+{
+  display:flex;
+}
+.macro-section {
+  display:flex;
+}
+
+.macro-section &gt; .xwiki-metadata-container.cke_widget_editable
+{
+  display:flex;
+  width:100%;
 }</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
@@ -137,6 +137,117 @@ Content in the column 4
   <object>
     <name>Confluence.Macros.Section</name>
     <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>53b642b6-9c41-4b19-95e8-b704b868e07f</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>require(['jquery'], ($) =&gt; {
+$(document).on('xwiki:dom:updated', function(event, data) {
+  $(this).find(".macro-section").each(function() {
+    $(this).find('.cke_widget_wrapper.cke_widget_block.cke_widget_xwiki-macro.cke_widget_wrapper_macro').each(function() {
+      const wrapper = $(this);
+      const column = wrapper.find(".macro-column");
+      wrapper.css('width', column.data("width"));
+      column.css('width', '');
+    });
+  });
+});
+});</code>
+    </property>
+    <property>
+      <name/>
+    </property>
+    <property>
+      <parse/>
+    </property>
+    <property>
+      <use/>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.Section</name>
+    <number>0</number>
     <className>XWiki.StyleSheetExtension</className>
     <guid>3fba5e5d-c70c-4531-8b12-a27d2122f2f3</guid>
     <class>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Section.xml
@@ -242,7 +242,7 @@ $(document).on('xwiki:dom:updated', function(event, data) {
       <parse/>
     </property>
     <property>
-      <use/>
+      <use>onDemand</use>
     </property>
   </object>
   <object>
@@ -355,9 +355,6 @@ $(document).on('xwiki:dom:updated', function(event, data) {
 }
 .macro-section
 {
-  display:flex;
-}
-.macro-section {
   display:flex;
 }
 

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
@@ -212,7 +212,7 @@ This macro supports all Atlassian Confluence parameters as of version 7.9.</cont
 }
 .macro-border {
   margin-bottom: 10px;
-  overflow: scroll;
+  overflow: hidden;
 }</code>
     </property>
     <property>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Panel.xml
@@ -212,7 +212,7 @@ This macro supports all Atlassian Confluence parameters as of version 7.9.</cont
 }
 .macro-border {
   margin-bottom: 10px;
-  overflow: hidden;
+  overflow: scroll;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
I've modified the structure of the cke wrappers using CSS and JavaScript to make the page look as expected. To be more precise, I've made the main wrapper a flex container to display each column on the same line and moved the width from the original element to its wrapper to keep the ratio used in the view mode.