### PR TITLE
Improve display of view-file macro #239

### DIFF
--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/DisplayType.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/DisplayType.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.viewfile;
+
+/**
+ * Supported display types by the view file macro.
+ *
+ * @version $Id$
+ * @since 1.17.2
+ */
+public enum DisplayType
+{
+    /**
+     * The selected document will be rendered in page.
+     */
+    FULL,
+    /**
+     * The selected document will be visible as a hyperlink to a modal where the content can be viewed.
+     */
+    THUMBNAIL
+}

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -492,7 +492,8 @@
   #set ($discard = $xwiki.ssx.use('Confluence.Macros.ViewFile'))
   #set($hasPDFViewer = $xwiki.exists("XWiki.PDFViewerMacro"))
   #set($officeExtensions = [ 'ppt', 'pptx', 'odp', 'doc', 'docx', 'odt', 'xls', 'xlsx', 'ods' ])
-  #set($presentationExtensions = [ 'ppt', 'pptx', 'odp'])
+  #set($presentationExtensions = [ 'ppt', 'pptx', 'odp' ])
+  #set($spreadsheetExtensions = [ 'xls', 'xlsx', 'ods' ])
   #set($unescapedFilename = $xcontext.macro.params.get('att--filename'))
   #if(!$unescapedFilename)
     #set($unescapedFilename = $xcontext.macro.params.get('name'))
@@ -525,12 +526,29 @@
     #elseif ($display == 'THUMBNAIL')
       #if (($extension == 'pdf' &amp;&amp; $hasPDFViewer) || $officeExtensions.contains($extension))
         #set ($modalId = $escapetool.xml($unescapedFilename.replaceAll("[^a-zA-Z]", "") + 'DisplayContentModal'))
-        &lt;div&gt;
-          &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;$escapedFilename&lt;/a&gt;
-        &lt;/div&gt;
         #if ($presentationExtensions.contains($extension))
+          &lt;div class="buttonwrapper"&gt;
+            &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
+              $services.icon.render('file-powerpoint') $escapedFilename&lt;/a&gt;
+          &lt;/div&gt;
           #displayPresentationContent($escapedFilename, $modalId)
         #else
+          #if($extension == 'pdf')
+            &lt;div class="buttonwrapper"&gt;
+              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
+                $services.icon.render('file-pdf') $escapedFilename&lt;/a&gt;
+            &lt;/div&gt;
+          #elseif($spreadsheetExtensions.contains($extension))
+            &lt;div class="buttonwrapper"&gt;
+              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
+                $services.icon.render('file-excel') $escapedFilename&lt;/a&gt;
+            &lt;/div&gt;
+          #else
+            &lt;div class="buttonwrapper"&gt;
+              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
+                $services.icon.render('file-word') $escapedFilename&lt;/a&gt;
+            &lt;/div&gt;
+          #end
           #displayContent($escapedFilename, $modalId, $extension)
         #end
       #elseif($doc.getAttachment($unescapedFilename))

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -62,6 +62,129 @@
   <object>
     <name>Confluence.Macros.ViewFile</name>
     <number>0</number>
+    <className>XWiki.StyleSheetExtension</className>
+    <guid>672b4948-8350-4fe0-b42c-5c7caeeb293d</guid>
+    <class>
+      <name>XWiki.StyleSheetExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <restricted>0</restricted>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>6</number>
+        <prettyName>Content Type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>CSS|LESS</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property>
+      <cache>long</cache>
+    </property>
+    <property>
+      <code>div.modal-body &gt; div &gt; iframe {
+    max-height: 75vh; !important
+}</code>
+    </property>
+    <property>
+      <contentType>CSS</contentType>
+    </property>
+    <property>
+      <name>viewFileCSS</name>
+    </property>
+    <property>
+      <parse>0</parse>
+    </property>
+    <property>
+      <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.ViewFile</name>
+    <number>0</number>
     <className>XWiki.WikiMacroClass</className>
     <guid>eb3146d5-be1c-418e-bf6a-f325a1c630e5</guid>
     <class>
@@ -263,24 +386,140 @@
     </property>
     <property>
       <code>{{velocity output="false"}}
+#macro(customBox $width $height $escapedFilename)
+  #if ($width &amp;&amp; !$width.contains("%"))
+    #set($width = $width + "px")
+  #end
+  #if ($height &amp;&amp; !$height.contains("%"))
+    #set($height = $height + "px")
+  #end
+  &lt;div class="box" style="width: $width; height: $height; overflow: auto;"&gt;
+
+  {{office reference="attach:$escapedFilename" /}}
+
+  &lt;/div&gt;
+#end
+#macro(customPresentationBox $width $height $escapedFilename)
+  #if ($width &amp;&amp; !$width.contains("%"))
+    #set($width = $width + "px")
+  #end
+  #if ($height &amp;&amp; !$height.contains("%"))
+    #set($height = $height + "px")
+  #end
+  &lt;div style="width: $width; height: $height; overflow: auto;"&gt;
+
+    {{office reference="attach:$escapedFilename" /}}
+
+  &lt;/div&gt;
+#end
+#macro (displayContent $escapedFilename, $modalId)
+  &lt;div class="modal fade" id="$modalId" tabindex="-1" role="dialog"
+      aria-labelledby="${modalId}Label"&gt;
+    &lt;div class="modal-dialog" style="max-height: 90vh; width: 80%;" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+          &lt;div id="${modalId}Label" class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('rendering.macro.viewFiles.modal.title'))
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body" style="max-height: 80vh; overflow: auto"&gt;
+
+        #if ($modalId.contains('pdf'))
+          {{pdfviewer file="$escapedFilename" /}}
+        #else
+          {{office reference="attach:$escapedFilename" /}}
+        #end
+
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
+#macro (displayPresentationContent $escapedFilename, $modalId)
+  &lt;div class="modal fade" id="$modalId" tabindex="-1" role="dialog"
+      aria-labelledby="${modalId}Label"&gt;
+    &lt;div class="modal-dialog" style="height:90%; width:90%; display:flex; flex-direction:column; align-items:center;" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+          &lt;div id="${modalId}Label" class="modal-title"&gt;
+            $escapetool.xml($services.localization.render('rendering.macro.viewFiles.modal.title'))
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+
+        {{office reference="attach:$escapedFilename" /}}
+
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))&lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
 #macro (executeMacro)
+  #set ($discard = $xwiki.ssx.use('Confluence.Macros.ViewFile'))
   #set($hasPDFViewer = $xwiki.exists("XWiki.PDFViewerMacro"))
   #set($officeExtensions = [ 'ppt', 'pptx', 'odp', 'doc', 'docx', 'odt', 'xls', 'xlsx', 'ods' ])
+  #set($presentationExtensions = [ 'ppt', 'pptx', 'odp'])
   #set($unescapedFilename = $xcontext.macro.params.get('att--filename'))
   #if(!$unescapedFilename)
     #set($unescapedFilename = $xcontext.macro.params.get('name'))
   #end
   #set($extension = $unescapedFilename.substring($mathtool.add($unescapedFilename.lastIndexOf('.'), 1)).toLowerCase())
   #set($escapedFilename = $services.rendering.escape($unescapedFilename, $xwiki.currentContentSyntaxId))
-  #if($extension == 'pdf' &amp;&amp; $hasPDFViewer)
+  #set($width = $xcontext.macro.params.get('width'))
+  #set($height = $xcontext.macro.params.get('height'))
+  #set($display = $xcontext.macro.params.get('display'))
+  #set($idName = $unescapedFilename.replaceAll("[^a-zA-Z]", ""))
+  {{html wiki="true" clean="false"}}
+    #if ($display == 'FULL')
+      #if ($presentationExtensions.contains($extension))
+        #if($height &gt; 390)
+          #set($height = '390')
+        #end
 
-    {{pdfviewer file="$escapedFilename" /}}
-  #elseif($officeExtensions.contains($extension))
+        #customPresentationBox($width $height $escapedFilename)
+      #elseif($extension == 'pdf' &amp;&amp; $hasPDFViewer)
 
-    {{office reference="attach:$escapedFilename" /}}
-  #elseif($doc.getAttachment($unescapedFilename))
-    [[attach:$escapedFilename]]
-  #end
+        {{pdfviewer file="$escapedFilename" height=$height width=$width/}}
+      #elseif($officeExtensions.contains($extension))
+
+        #customBox($width $height $escapedFilename)
+      #elseif($doc.getAttachment($unescapedFilename))
+        #set ($downloadUrl = $xwiki.getAttachmentURL($doc.getFullName(), $unescapedFilename))
+        &lt;div&gt;
+          &lt;a href="$downloadUrl" download&gt;$escapedFilename&lt;br&gt;&lt;/a&gt;
+        &lt;/div&gt;
+      #end
+    #elseif ($display == 'THUMBNAIL')
+      #if (($extension == 'pdf' &amp;&amp; $hasPDFViewer) || $officeExtensions.contains($extension))
+        #set ($modalId = $idName + 'DisplayContentModal')
+        &lt;div&gt;
+          &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;$escapedFilename&lt;/a&gt;
+        &lt;/div&gt;
+        #if ($presentationExtensions.contains($extension))
+          #displayPresentationContent($escapedFilename, $modalId)
+        #else
+          #displayContent($escapedFilename, $modalId)
+        #end
+      #elseif($doc.getAttachment($unescapedFilename))
+        #set ($downloadUrl = $xwiki.getAttachmentURL($doc.getFullName(), $unescapedFilename))
+        &lt;div&gt;
+          &lt;a href="$downloadUrl" download&gt;$escapedFilename&lt;/a&gt;
+        &lt;/div&gt;
+      #end
+    #end
+  {{/html}}
 #end
 {{/velocity}}
 
@@ -401,7 +640,244 @@
       <name>att--filename</name>
     </property>
     <property>
+      <type>org.xwiki.model.reference.AttachmentReference</type>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.ViewFile</name>
+    <number>1</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>40e023d7-bb84-4f86-9360-232599d7165d</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>100%</defaultValue>
+    </property>
+    <property>
+      <description>The viewer width, accepts values in pixels or in percentage.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>width</name>
+    </property>
+    <property>
       <type/>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.ViewFile</name>
+    <number>2</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>04a88864-2cd5-493e-bea3-71598f18146f</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>1000</defaultValue>
+    </property>
+    <property>
+      <description>The viewer height, accepts values in pixels.</description>
+    </property>
+    <property>
+      <mandatory/>
+    </property>
+    <property>
+      <name>height</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>Confluence.Macros.ViewFile</name>
+    <number>3</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>aa20b8bc-13bc-4c2f-9274-06800a98d60b</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <restricted>0</restricted>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue>full</defaultValue>
+    </property>
+    <property>
+      <description>Display type.</description>
+    </property>
+    <property>
+      <mandatory>1</mandatory>
+    </property>
+    <property>
+      <name>display</name>
+    </property>
+    <property>
+      <type>com.xwiki.macros.viewfile.DisplayType</type>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -185,6 +185,10 @@
   display:flex;
   flex-direction:column;
   align-items:center;
+}
+
+.thumbnailButton button: hover {
+  text-decoration: underline;
 }</code>
     </property>
     <property>
@@ -404,7 +408,12 @@
     </property>
     <property>
       <code>{{velocity output="false"}}
-#macro(customBox $width $height $escapedFilename)
+#macro (renderThumbnailButton $fileType $escapedFilename)
+  &lt;div class="buttonwrapper thumbnailButton"&gt;
+    &lt;button data-toggle="modal" data-target="#${modalId}"&gt;$services.icon.render("${fileType}") $escapedFilename&lt;/button&gt;
+  &lt;/div&gt;
+#end
+#macro (customBox $width $height $escapedFilename)
   #if ($width &amp;&amp; !$width.contains("%"))
     #set($width = $width + "px")
   #end
@@ -413,11 +422,11 @@
   #end
   &lt;div class="box" style="width: $escapetool.xml($width); height: $escapetool.xml($height); overflow: auto;"&gt;
 
-  {{office reference="attach:$escapedFilename" /}}
+    {{office reference="attach:$escapedFilename" /}}
 
   &lt;/div&gt;
 #end
-#macro(customPresentationBox $width $height $escapedFilename)
+#macro (customPresentationBox $width $height $escapedFilename)
   #if ($width &amp;&amp; !$width.contains("%"))
     #set($width = $width + "px")
   #end
@@ -477,7 +486,7 @@
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
 
-        {{office reference="attach:$escapedFilename" /}}
+          {{office reference="attach:$escapedFilename" /}}
 
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
@@ -527,27 +536,15 @@
       #if (($extension == 'pdf' &amp;&amp; $hasPDFViewer) || $officeExtensions.contains($extension))
         #set ($modalId = $escapetool.xml($unescapedFilename.replaceAll("[^a-zA-Z]", "") + 'DisplayContentModal'))
         #if ($presentationExtensions.contains($extension))
-          &lt;div class="buttonwrapper"&gt;
-            &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
-              $services.icon.render('file-powerpoint') $escapedFilename&lt;/a&gt;
-          &lt;/div&gt;
+          #renderThumbnailButton('file-powerpoint', $escapedFilename)
           #displayPresentationContent($escapedFilename, $modalId)
         #else
           #if($extension == 'pdf')
-            &lt;div class="buttonwrapper"&gt;
-              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
-                $services.icon.render('file-pdf') $escapedFilename&lt;/a&gt;
-            &lt;/div&gt;
+            #renderThumbnailButton('file-pdf', $escapedFilename)
           #elseif($spreadsheetExtensions.contains($extension))
-            &lt;div class="buttonwrapper"&gt;
-              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
-                $services.icon.render('file-excel') $escapedFilename&lt;/a&gt;
-            &lt;/div&gt;
+            #renderThumbnailButton('file-excel', $escapedFilename)
           #else
-            &lt;div class="buttonwrapper"&gt;
-              &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;
-                $services.icon.render('file-word') $escapedFilename&lt;/a&gt;
-            &lt;/div&gt;
+            #renderThumbnailButton('file-word', $escapedFilename)
           #end
           #displayContent($escapedFilename, $modalId, $extension)
         #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -410,7 +410,9 @@
       <code>{{velocity output="false"}}
 #macro (renderThumbnailButton $fileType $escapedFilename)
   &lt;div class="buttonwrapper thumbnailButton"&gt;
-    &lt;button data-toggle="modal" data-target="#${modalId}"&gt;$services.icon.render("${fileType}") $escapedFilename&lt;/button&gt;
+    &lt;button data-toggle="modal" data-target="#${modalId}" title="$escapetool.xml($services.localization.render(
+      'rendering.macro.viewFile.thumbnail.button.title'))"&gt;$services.icon.render("${fileType}") $escapedFilename
+    &lt;/button&gt;
   &lt;/div&gt;
 #end
 #macro (customBox $width $height $escapedFilename)
@@ -448,7 +450,7 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
           &lt;div id="${modalId}Label" class="modal-title"&gt;
-            $escapetool.xml($services.localization.render('rendering.macro.viewFiles.modal.title'))
+            $escapetool.xml($services.localization.render('rendering.macro.viewFile.modal.title'))
           &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
@@ -481,7 +483,7 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
           &lt;div id="${modalId}Label" class="modal-title"&gt;
-            $escapetool.xml($services.localization.render('rendering.macro.viewFiles.modal.title'))
+            $escapetool.xml($services.localization.render('rendering.macro.viewFile.modal.title'))
           &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -165,8 +165,26 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>div.modal-body &gt; div &gt; iframe {
-    max-height: 75vh; !important
+      <code>.pdfViewContent &gt; div &gt; iframe {
+    max-height: 75vh;
+}
+
+.viewFileContentThumb .modal-dialog {
+  max-height: 90vh;
+  width: 80%;
+}
+
+.viewFileContentThumb .modal-body {
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.viewFilePresentationContentThumb .modal-dialog {
+  height:90%;
+  width:90%;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
 }</code>
     </property>
     <property>
@@ -393,7 +411,7 @@
   #if ($height &amp;&amp; !$height.contains("%"))
     #set($height = $height + "px")
   #end
-  &lt;div class="box" style="width: $width; height: $height; overflow: auto;"&gt;
+  &lt;div class="box" style="width: $escapetool.xml($width); height: $escapetool.xml($height); overflow: auto;"&gt;
 
   {{office reference="attach:$escapedFilename" /}}
 
@@ -406,16 +424,16 @@
   #if ($height &amp;&amp; !$height.contains("%"))
     #set($height = $height + "px")
   #end
-  &lt;div style="width: $width; height: $height; overflow: auto;"&gt;
+  &lt;div style="width: $escapetool.xml($width); height: $escapetool.xml($height); overflow: auto;"&gt;
 
     {{office reference="attach:$escapedFilename" /}}
 
   &lt;/div&gt;
 #end
-#macro (displayContent $escapedFilename, $modalId)
-  &lt;div class="modal fade" id="$modalId" tabindex="-1" role="dialog"
+#macro (displayContent $escapedFilename, $modalId, $extension)
+  &lt;div class="modal fade viewFileContentThumb" id="${modalId}" tabindex="-1" role="dialog"
       aria-labelledby="${modalId}Label"&gt;
-    &lt;div class="modal-dialog" style="max-height: 90vh; width: 80%;" role="document"&gt;
+    &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
@@ -424,14 +442,18 @@
             $escapetool.xml($services.localization.render('rendering.macro.viewFiles.modal.title'))
           &lt;/div&gt;
         &lt;/div&gt;
-        &lt;div class="modal-body" style="max-height: 80vh; overflow: auto"&gt;
+        &lt;div class="modal-body"&gt;
+        #if ($extension == 'pdf')
+          &lt;div class='pdfViewContent'&gt;
 
-        #if ($modalId.contains('pdf'))
-          {{pdfviewer file="$escapedFilename" /}}
+            {{pdfviewer file="$escapedFilename" /}}
+
+          &lt;/div&gt;
         #else
-          {{office reference="attach:$escapedFilename" /}}
-        #end
 
+          {{office reference="attach:$escapedFilename" /}}
+
+        #end
         &lt;/div&gt;
         &lt;div class="modal-footer"&gt;
           &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
@@ -442,9 +464,9 @@
   &lt;/div&gt;
 #end
 #macro (displayPresentationContent $escapedFilename, $modalId)
-  &lt;div class="modal fade" id="$modalId" tabindex="-1" role="dialog"
+  &lt;div class="modal fade viewFilePresentationContentThumb" id="${modalId}" tabindex="-1" role="dialog"
       aria-labelledby="${modalId}Label"&gt;
-    &lt;div class="modal-dialog" style="height:90%; width:90%; display:flex; flex-direction:column; align-items:center;" role="document"&gt;
+    &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
@@ -480,7 +502,6 @@
   #set($width = $xcontext.macro.params.get('width'))
   #set($height = $xcontext.macro.params.get('height'))
   #set($display = $xcontext.macro.params.get('display'))
-  #set($idName = $unescapedFilename.replaceAll("[^a-zA-Z]", ""))
   {{html wiki="true" clean="false"}}
     #if ($display == 'FULL')
       #if ($presentationExtensions.contains($extension))
@@ -503,14 +524,14 @@
       #end
     #elseif ($display == 'THUMBNAIL')
       #if (($extension == 'pdf' &amp;&amp; $hasPDFViewer) || $officeExtensions.contains($extension))
-        #set ($modalId = $idName + 'DisplayContentModal')
+        #set ($modalId = $escapetool.xml($unescapedFilename.replaceAll("[^a-zA-Z]", "") + 'DisplayContentModal'))
         &lt;div&gt;
           &lt;a href="#${modalId}" data-toggle="modal" data-target="#${modalId}"&gt;$escapedFilename&lt;/a&gt;
         &lt;/div&gt;
         #if ($presentationExtensions.contains($extension))
           #displayPresentationContent($escapedFilename, $modalId)
         #else
-          #displayContent($escapedFilename, $modalId)
+          #displayContent($escapedFilename, $modalId, $extension)
         #end
       #elseif($doc.getAttachment($unescapedFilename))
         #set ($downloadUrl = $xwiki.getAttachmentURL($doc.getFullName(), $unescapedFilename))
@@ -710,7 +731,7 @@
       <defaultValue>100%</defaultValue>
     </property>
     <property>
-      <description>The viewer width, accepts values in pixels or in percentage.</description>
+      <description/>
     </property>
     <property>
       <mandatory>0</mandatory>
@@ -789,7 +810,7 @@
       <defaultValue>1000</defaultValue>
     </property>
     <property>
-      <description>The viewer height, accepts values in pixels.</description>
+      <description/>
     </property>
     <property>
       <mandatory/>
@@ -868,7 +889,7 @@
       <defaultValue>full</defaultValue>
     </property>
     <property>
-      <description>Display type.</description>
+      <description/>
     </property>
     <property>
       <mandatory>1</mandatory>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -163,15 +163,16 @@ rendering.macro.userList.isEmpty=The User List macro has an empty user list.
 rendering.macro.userList.invalidUser=User {0} does not exist or is not viewable.
 
 ## View Files macro
-rendering.macro.viewFiles.modal.title=Content view
 com.xwiki.macros.viewfile.DisplayType.FULL=Full
 com.xwiki.macros.viewfile.DisplayType.THUMBNAIL=Thumbnail
-rendering.macro.view-file.parameter.width.name=Width
-rendering.macro.view-file.parameter.width.description=The viewer width, accepts values in pixels or in percentage.
+rendering.macro.view-file.parameter.display.name=Display
+rendering.macro.view-file.parameter.display.description=Display type.
 rendering.macro.view-file.parameter.height.name=Height
 rendering.macro.view-file.parameter.height.description=The viewer height, accepts values in pixels.
-rendering.macro.view-file.parameter.display.name=Display
-rendering.macro.view-file.parameter.display.description=Display type.</content>
+rendering.macro.view-file.parameter.width.name=Width
+rendering.macro.view-file.parameter.width.description=The viewer width, accepts values in pixels or in percentage.
+rendering.macro.viewFile.modal.title=Content view
+rendering.macro.viewFile.thumbnail.button.title=View file content</content>
   <object>
     <name>XWiki.Macros.Translations</name>
     <number>0</number>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -165,7 +165,13 @@ rendering.macro.userList.invalidUser=User {0} does not exist or is not viewable.
 ## View Files macro
 rendering.macro.viewFiles.modal.title=Content view
 com.xwiki.macros.viewfile.DisplayType.FULL=Full
-com.xwiki.macros.viewfile.DisplayType.THUMBNAIL=Thumbnail</content>
+com.xwiki.macros.viewfile.DisplayType.THUMBNAIL=Thumbnail
+rendering.macro.view-file.parameter.width.name=Width
+rendering.macro.view-file.parameter.width.description=The viewer width, accepts values in pixels or in percentage.
+rendering.macro.view-file.parameter.height.name=Height
+rendering.macro.view-file.parameter.height.description=The viewer height, accepts values in pixels.
+rendering.macro.view-file.parameter.display.name=Display
+rendering.macro.view-file.parameter.display.description=Display type.</content>
   <object>
     <name>XWiki.Macros.Translations</name>
     <number>0</number>

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.xml
@@ -160,7 +160,12 @@ rendering.macro.userList.parameter.properties.description=List of user propertie
 rendering.macro.userList.parameter.fixedTableLayout.name=Fixed table layout
 rendering.macro.userList.parameter.fixedTableLayout.description=If the user table should have fixed column width across tables displaying the same user properties
 rendering.macro.userList.isEmpty=The User List macro has an empty user list.
-rendering.macro.userList.invalidUser=User {0} does not exist or is not viewable.</content>
+rendering.macro.userList.invalidUser=User {0} does not exist or is not viewable.
+
+## View Files macro
+rendering.macro.viewFiles.modal.title=Content view
+com.xwiki.macros.viewfile.DisplayType.FULL=Full
+com.xwiki.macros.viewfile.DisplayType.THUMBNAIL=Thumbnail</content>
   <object>
     <name>XWiki.Macros.Translations</name>
     <number>0</number>


### PR DESCRIPTION
Created modals and custom box macro to better display the files used with the `view-files` macro.

* Macro view:
![macro](https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/05d447fa-5190-4d5c-9449-03d5afed1ca5)
![macro-select](https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/5f1f6119-8368-4389-8113-58f14f63008a)

* Full view:
![full-view1](https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/66cf5160-6911-425f-9a0e-30debf6df263)
![full-view2](https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/d50ae7f6-1c56-402a-a67d-d517b525de0f)

* Table test:
![table-test](https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/5a037049-ac0d-4ea7-964d-b6a42002b1a4)

* Thumbnail demo:
https://github.com/xwikisas/xwiki-pro-macros/assets/104432589/a1970431-2657-4600-acff-23733bcab5ba

  * The thumbnail option only returns a hyperlink to a modal to view the selected file, without an image preview, as currently there is no support for creating an image from an office or pdf file.


