### PR TITLE
Team macro not working when selecting a Tag #244

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
@@ -845,7 +845,7 @@
       obj3.className = 'XWiki.TagClass' and
       obj3.id = tagprop.id.id and
       tagprop.id.name = 'tags' and
-      list = ':tag'
+      list = :tag
     ")
   #end
   #set($hql = ",


### PR DESCRIPTION
* The issue was caused by some unnecessary quotes in the query, which prevented the bind from working properly.