### PR TITLE
The expand macro generates invalid HTML #295

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -164,12 +164,11 @@ Hello 👀
   transform: rotate(90deg);
 }
 
-.confluence-expand-macro {
+.confluence-expand-macro .panel-title{
   padding: @panel-heading-padding;
+  display: block;
 }
-.panel-title {
-  padding: 5px;
-}
+
 .confluence-expand-macro .panel-body {
   transition: linear 0.3s;
 }

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -164,10 +164,12 @@ Hello 👀
   transform: rotate(90deg);
 }
 
-.confluence-expand-macro .panel-title {
+.confluence-expand-macro {
   padding: @panel-heading-padding;
 }
-
+.panel-title {
+  padding: 5px;
+}
 .confluence-expand-macro .panel-body {
   transition: linear 0.3s;
 }
@@ -422,10 +424,10 @@ Hello 👀
   {{html clean="false" wiki="true"}}
   &lt;details class="confluence-expand-macro panel panel-default" #if ($opened)open#end&gt;
     &lt;summary&gt;
-      &lt;div class="panel-title"&gt;
+      &lt;span class="panel-title"&gt;
         &lt;span class="glyphicon glyphicon-menu-right" aria-hidden="true"&gt;&lt;/span&gt;
         $services.rendering.escape($escapetool.xml("${wikimacro.parameters.title}"), 'xwiki/2.1')
-     &lt;/div&gt;
+     &lt;/span&gt;
     &lt;/summary&gt;
     &lt;div class="panel-body"&gt;
 


### PR DESCRIPTION
* Modified the content of the summary tag to be composed of a span instead of a div and added some css to preserve the old look.