### PR TITLE
Single-column layout doesn't cover page width #206.

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -197,8 +197,7 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
     margin: 0;
   }
 }
-.macro-layout-cell {
-}</code>
+</code>
     </property>
     <property>
       <contentType>LESS</contentType>


### PR DESCRIPTION
 The issue was caused by a CSS class that was meant to leave a gap between the columns, but it overlooked the fact that the rule would indent the first column. To resolve this, I've removed the margin-left CSS and added a gap to the flex element so the columns have the same space between them.

Preview: 
![image](https://github.com/user-attachments/assets/4a7459f4-d8d6-4ee8-98e0-1097dd67ea31)
