### PR TITLE
Conversion from Confluence diagram fails without visible error message

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramService.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramService.xml
@@ -64,22 +64,29 @@
       #getUniquePageReference($xwiki.getDocument($page).space $uniquePageReference)
       #set($diagramContent = $diagramAttach.getContentAsString())
       #set($diagramPNGContent = $diagramPreviewAttach.getContentAsString())
-      #if($diagramContent.contains('&lt;mxfile ') &amp;&amp; $diagramContent.contains('&lt;diagram '))
+      #if($diagramContent.contains('&lt;mxfile ') &amp;&amp; ($diagramContent.contains('&lt;diagram ') || $diagramContent.contains('&lt;diagram&gt;')))
         ## Drawio
         #set($xml = $diagramContent)
       #else
         #set($xml = $services.diagram.importDiagram($diagramContent, $diagramName))
       #end
-      #set($diagramDoc = $xwiki.getDocument($uniquePageReference))
-      #set($discard = $diagramDoc.addObject($diagramDoc.newObject('Diagram.DiagramClass')))
-      #set($discard = $diagramDoc.setContent($xml))
-      #set($discard = $diagramDoc.setTitle('Diagram'))
-      #set($diagramObj = $diagramDoc.newObject('Confluence.Macros.DiagramClass'))
-      #set($discard = $diagramObj.set('page', $page))
-      #set($discard = $diagramObj.set('diagramName', $diagramName))
-      #set($discard = $diagramDoc.addObject($diagramObj))
-      #set($diagramPreviewPNG = $diagramDoc.addAttachment('diagram.png', $diagramPreviewAttach.getContent()))
-      #set($discard = $diagramDoc.save($services.localization.render('confluencediagram.create.message')))
+      #if ("$!xml" != '')
+        #set($diagramDoc = $xwiki.getDocument($uniquePageReference))
+        #set($discard = $diagramDoc.addObject($diagramDoc.newObject('Diagram.DiagramClass')))
+        #set($discard = $diagramDoc.setContent($xml))
+        #set($discard = $diagramDoc.setTitle('Diagram'))
+        #set($diagramObj = $diagramDoc.newObject('Confluence.Macros.DiagramClass'))
+        #set($discard = $diagramObj.set('page', $page))
+        #set($discard = $diagramObj.set('diagramName', $diagramName))
+        #set($discard = $diagramDoc.addObject($diagramObj))
+        #set($diagramPreviewPNG = $diagramDoc.addAttachment('diagram.png', $diagramPreviewAttach.getContent()))
+        #set($discard = $diagramDoc.save($services.localization.render('confluencediagram.create.message')))
+      #else
+        ## Bad Request
+        #set($logger = $services.logging.getLogger('com.xwiki.macros.diagram.DiagramService'))
+        #set($discard = $logger.warn("could not convert diagram from [{}]; no data found", $diagramAttach.getReference()))
+        $response.setStatus(400)
+      #end
     #else
       ## Bad Request
       $response.setStatus(400)


### PR DESCRIPTION
- in case the XML for the diagram is empty, return an error
- handle case where the `diagram` element in the XML has no further attributes

Fixes [application-diagram#276](https://github.com/xwikisas/application-diagram/issues/276) (which I reported in the wrong project)