### PR TITLE
 Column Macro - can't add 2 or more columns in WYSIWYG or in-place editing #241

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceColumn.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceColumn.xml
@@ -429,7 +429,7 @@ This macro is a bridge for the Confluence Column macro. This macro is used in co
       <priority/>
     </property>
     <property>
-      <supportsInlineMode>1</supportsInlineMode>
+      <supportsInlineMode>0</supportsInlineMode>
     </property>
     <property>
       <visibility>Current Wiki</visibility>


### PR DESCRIPTION
 * Modified the macro to not support inline.