### PR TITLE
Add confluence toc-zone macro bridge.

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/checkstyle-suppressions.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/checkstyle-suppressions.xml
@@ -7,4 +7,6 @@
 <suppressions>
   <suppress checks="ClassFanOutComplexity"
             files="src/main/java/com/xwiki/macros/confluence/ConfluenceOutgoingLinksMacro\.java"/>
+  <suppress checks="ClassFanOutComplexity"
+            files="src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacro\.java"/>
 </suppressions>

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacro.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacro.java
@@ -1,0 +1,421 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.confluence;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.BulletedListBlock;
+import org.xwiki.rendering.block.GroupBlock;
+import org.xwiki.rendering.block.HeaderBlock;
+import org.xwiki.rendering.block.LinkBlock;
+import org.xwiki.rendering.block.ListBLock;
+import org.xwiki.rendering.block.ListItemBlock;
+import org.xwiki.rendering.block.MetaDataBlock;
+import org.xwiki.rendering.block.ParagraphBlock;
+import org.xwiki.rendering.block.SpaceBlock;
+import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.match.AnyBlockMatcher;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+import org.xwiki.rendering.macro.MacroContentParser;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
+import org.xwiki.rendering.renderer.printer.WikiPrinter;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.stability.Unstable;
+
+import com.xwiki.macros.AbstractProMacro;
+
+/**
+ * The Confluence outgoing-links bridge macro.
+ * 
+ * @since 1.22.4
+ * @version $Id$
+ */
+@Component
+@Named("confluence_toc-zone")
+@Singleton
+@Unstable
+public class ConfluenceTocZoneMacro extends AbstractProMacro<ConfluenceTocZoneMacroParameters>
+{
+    private static final String SEMICOLUMN = ";";
+
+    @Inject
+    private MacroContentParser contentParser;
+
+    @Inject
+    @Named("plain/1.0")
+    private BlockRenderer plainTextRenderer;
+
+    /**
+     * Constructor.
+     */
+    public ConfluenceTocZoneMacro()
+    {
+        super("Confluence Toc Zone", "Confluence bridge macro for toc-zone.",
+            new DefaultContentDescriptor("Content", true, Block.LIST_BLOCK_TYPE),
+            ConfluenceTocZoneMacroParameters.class);
+    }
+
+    @Override
+    public List<Block> internalExecute(ConfluenceTocZoneMacroParameters parameters, String content,
+        MacroTransformationContext context) throws MacroExecutionException
+    {
+
+        // The parsed content of the macro.
+        List<Block> contentXDOM = parseContent(content, context);
+
+        // We need to do a first XDOM traversal to know the minimal heading level.
+        int levelOffset = getLevelOffset(contentXDOM, parameters);
+
+        // Generate the TOC.
+        Block toc;
+        if (parameters.getType().equals(ConfluenceTocZoneMacroTypeParameter.FLAT)) {
+            toc = browseXDOMFlat(contentXDOM, levelOffset, context, parameters);
+        } else {
+            toc = browseXDOMList(contentXDOM, levelOffset, parameters);
+        }
+
+        // Wrap the TOC in a div when we need to add a class.
+        StringBuilder classes = new StringBuilder("");
+        if (!parameters.isPrintable()) {
+            classes.append("hidden-print ");
+        }
+        classes.append(parameters.getCssClass());
+
+        if (!"".equals(classes.toString())) {
+            toc = new GroupBlock(Arrays.asList(toc), Collections.singletonMap("class", classes.toString()));
+        }
+
+        // Display the TOC somewhere around the editable content.
+        List<Block> result = new ArrayList<>();
+        switch (parameters.getLocation()) {
+            case TOP:
+                result.add(toc);
+                result.addAll(contentXDOM);
+                break;
+            case BOTTOM:
+                result.addAll(contentXDOM);
+                result.add(toc);
+                break;
+            default:
+                result.add(toc);
+                result.addAll(contentXDOM);
+                result.add(toc);
+                break;
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return false;
+    }
+
+    private Block browseXDOMFlat(List<Block> body, int levelOffset, MacroTransformationContext context,
+        ConfluenceTocZoneMacroParameters parameters) throws MacroExecutionException
+    {
+        Block toc = new ParagraphBlock(new ArrayList<>());
+
+        // We keep track of the number of headings per level to display the outline when requested.
+        List<Integer> outlineLevels = new ArrayList<>();
+
+        // Set the separators according to the macro parameters.
+        String separatorBefore = "";
+        String separatorAfter = "";
+        String separator = "";
+        switch (parameters.getSeparator()) {
+            case "brackets":
+                separatorBefore = "[ ";
+                separatorAfter = " ] ";
+                break;
+            case "braces":
+                separatorBefore = "{ ";
+                separatorAfter = " } ";
+                break;
+            case "parens":
+                separatorBefore = "( ";
+                separatorAfter = " ) ";
+                break;
+            case "pipe":
+                separator = " | ";
+                break;
+            default:
+                separator = parameters.getSeparator();
+        }
+
+        // Keep track of the last sperator's blocks to remove them after the last iteration.
+        // The separator is only between the elements.
+        List<Block> lastSeparator = Arrays.asList();
+
+        // Traverse the XDOM and find all Headings, in order.
+        for (Block block : body) {
+            for (Block b : block.getBlocks(new AnyBlockMatcher(), Block.Axes.DESCENDANT)) {
+                if (b instanceof HeaderBlock) {
+                    HeaderBlock header = (HeaderBlock) b;
+
+                    // Check if we should ignore this heading.
+                    if (filterHeader(header, parameters)) {
+                        continue;
+                    }
+
+                    // Compute the heading's relative level in this TOC.
+                    int level = (header).getLevel().getAsInt() + levelOffset;
+
+                    // We parse the separator text because it might contain more than just alphanumeric characters.
+                    toc.addChildren(parseReadOnlyContent(separatorBefore, context));
+
+                    // Add the outline if there is one.
+                    toc.addChild(getOutline(level, outlineLevels, parameters));
+                    toc.addChild(new SpaceBlock());
+
+                    // Add the link to the heading.
+                    toc.addChild(getHeaderLink(header));
+
+                    toc.addChildren(parseReadOnlyContent(separatorAfter, context));
+
+                    lastSeparator = parseReadOnlyContent(separator, context);
+                    toc.addChildren(lastSeparator);
+                }
+            }
+        }
+
+        // Remove the last separator.
+        for (Block block : lastSeparator) {
+            toc.removeBlock(block);
+        }
+
+        return toc;
+    }
+
+    private Block browseXDOMList(List<Block> body, int levelOffset, ConfluenceTocZoneMacroParameters parameters)
+    {
+        // Keep track of the BulletedListBlocks that hold the different levels.
+        List<ListBLock> levels = new ArrayList<>();
+
+        // Keep track of the number of heading in each level to generate the outline.
+        List<Integer> outlineLevels = new ArrayList<>();
+
+        // Allow for setting the bullet style.
+        Map<String, String> listParameters = Collections.emptyMap();
+
+        StringBuilder style = new StringBuilder("");
+
+        if (!"default".equals(parameters.getStyle())) {
+
+            style.append("list-style-type: " + parameters.getStyle() + SEMICOLUMN);
+        }
+
+        if (!"".equals(parameters.getIndent())) {
+            style.append("padding-inline-start: " + parameters.getIndent() + SEMICOLUMN);
+        }
+
+        if (!"".equals(style.toString())) {
+            listParameters = Collections.singletonMap("style", style.toString());
+        }
+        // Traverse the XDOM and iterate over the headings, in order.
+        for (Block block : body) {
+            for (Block b : block.getBlocks(new AnyBlockMatcher(), Block.Axes.DESCENDANT)) {
+                if (b instanceof HeaderBlock) {
+                    HeaderBlock header = (HeaderBlock) b;
+
+                    // Check if we should ignore this heading.
+                    if (filterHeader(header, parameters)) {
+                        continue;
+                    }
+
+                    // Compute the heading's relative level in this TOC.
+                    int level = (header).getLevel().getAsInt() + levelOffset;
+
+                    // Create the new TOC level.
+                    getNewLevel(level, levels, listParameters)
+                        // Add an entry with the outline and link.
+                        .addChild(new ListItemBlock(Arrays.asList(getOutline(level, outlineLevels, parameters),
+                            new SpaceBlock(), getHeaderLink(header))));
+                }
+            }
+        }
+
+        // The lowest level holds the whole TOC.
+        if (levels.size() > 0) {
+            return levels.get(0);
+        } else {
+            return new WordBlock("");
+        }
+
+    }
+
+    private LinkBlock getHeaderLink(HeaderBlock b)
+    {
+        // The anchor we need to link to is simply the id of the heading.
+        // To keep the same displayed text, we keep the same children blocks as the heading's.
+        return new LinkBlock(b.getChildren(), new ResourceReference("#" + b.getId(), ResourceType.URL), false);
+    }
+
+    private int getLevelOffset(List<Block> body, ConfluenceTocZoneMacroParameters parameters)
+    {
+        // When computing a min, we initialize with the maximum possible value.
+        int minLevel = Integer.MAX_VALUE;
+
+        // Iterate through the headings.
+        for (Block block : body) {
+            for (Block b : block.getBlocks(new AnyBlockMatcher(), Block.Axes.DESCENDANT)) {
+                if (b instanceof HeaderBlock) {
+                    HeaderBlock header = (HeaderBlock) b;
+
+                    // Check if we should ignore the heading.
+                    if (filterHeader(header, parameters)) {
+                        continue;
+                    }
+
+                    // Update the minimum level.
+                    int level = header.getLevel().getAsInt();
+                    minLevel = Integer.min(level, minLevel);
+                }
+            }
+        }
+
+        // The offset is something we add.
+        // This is why the value is the opposite of the minimum level.
+        return -minLevel;
+    }
+
+    private boolean filterHeader(HeaderBlock header, ConfluenceTocZoneMacroParameters parameters)
+    {
+        int level = header.getLevel().getAsInt();
+
+        // Skip heading if the level is below minimum value.
+        if (level < parameters.getMinLevel()) {
+            return true;
+        }
+
+        // Skip heading if the level is above maximum value.
+        if (level > parameters.getMaxLevel()) {
+            return true;
+        }
+
+        // In order to filter based on the text of the heading using a regex, we need to convert its XDOM to text.
+        // we use the plainTextRenderer for this purpose.
+        WikiPrinter printer = new DefaultWikiPrinter();
+        plainTextRenderer.render(header, printer);
+
+        // Skip heading if the parsed text does not match the include regex.
+        Pattern includeRegex = Pattern.compile(parameters.getInclude());
+        if (!includeRegex.matcher(printer.toString()).find()) {
+            return true;
+        }
+
+        // Skip heading if the parsed text matches the exclude regex.
+        Pattern excludeRegex = Pattern.compile(parameters.getExclude());
+        if (excludeRegex.matcher(printer.toString()).find()) {
+            return true;
+        }
+
+        // If all the checks passed, we can keep this heading.
+        return false;
+    }
+
+    private Block getOutline(int level, List<Integer> levels, ConfluenceTocZoneMacroParameters parameters)
+    {
+        StringBuilder outline = new StringBuilder("");
+
+        // We keep the levels List updated as we give the outline for the new heading.
+
+        // When we have a heading with a lower level than the previous one (i.e. more important),
+        // we need to get rid of the counters for higher levels.
+        for (int i = levels.size() - 1; i > level; i--) {
+            levels.remove(i);
+        }
+
+        // When we have a heading with a higher level than the previous one (i.e. less important),
+        // we need to create all the sublevel's counters.
+        for (int i = levels.size() - 1; i < level; i++) {
+            levels.add(levels.size() + 1 != level ? 0 : 1);
+        }
+
+        // Update the counter for the current level.
+        levels.set(level, levels.get(level) + 1);
+
+        // Build the outline, if requested.
+        if (parameters.isOutline()) {
+            outline.append(levels.get(0));
+            for (int i = 1; i <= level; i++) {
+                outline.append(".");
+                outline.append(levels.get(i));
+            }
+        }
+
+        return new WordBlock(outline.toString());
+    }
+
+    private ListBLock getNewLevel(int level, List<ListBLock> levels, Map<String, String> listParameters)
+    {
+        // Initialize the levels list.
+        if (levels.isEmpty()) {
+            levels.add(new BulletedListBlock(new ArrayList<>(), listParameters));
+        }
+
+        // When we have a heading with a lower level than the previous one (i.e. more important),
+        // we need to get rid of the lists for higher levels.
+        for (int i = levels.size() - 1; i > level; i--) {
+            levels.remove(i);
+        }
+
+        // When we have a heading with a higher level than the previous one (i.e. less important),
+        // we need to create all the sublevel's counters.
+        for (int i = levels.size() - 1; i < level; i++) {
+            levels.add(new BulletedListBlock(new ArrayList<>(), listParameters));
+            levels.get(i).addChild(levels.get(i + 1));
+        }
+
+        // Return the target level.
+        return levels.get(level);
+
+    }
+
+    private List<Block> parseContent(String content, MacroTransformationContext context) throws MacroExecutionException
+    {
+        // Don't execute transformations explicitly. They'll be executed on the generated content later on.
+        List<Block> children = contentParser.parse(content, context, false, context.isInline()).getChildren();
+
+        return Collections.singletonList(new MetaDataBlock(children, this.getNonGeneratedContentMetaData()));
+    }
+
+    private List<Block> parseReadOnlyContent(String content, MacroTransformationContext context)
+        throws MacroExecutionException
+    {
+        return contentParser.parse(content, context, false, true).getChildren();
+    }
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroLocationParameter.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroLocationParameter.java
@@ -1,0 +1,44 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.xwiki.macros.confluence;
+
+/**
+ * Defines where the Table of Contents should appear.
+ * 
+ * @version $Id$
+ * @since 1.22.4
+ */
+public enum ConfluenceTocZoneMacroLocationParameter
+{
+    /**
+     * Display the TOC above the macro's content.
+     */
+    TOP,
+    /**
+     * Display the TOC below the macro's content.
+     */
+    BOTTOM,
+    /**
+     * Display the TOC both above and below the macro's content.
+     * Note: This is the default.
+     */
+    BOTH
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroParameters.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroParameters.java
@@ -1,0 +1,314 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.confluence;
+
+import org.xwiki.properties.annotation.PropertyDescription;
+import org.xwiki.properties.annotation.PropertyId;
+import org.xwiki.stability.Unstable;
+
+/**
+ * confluence_toc-zone parameters.
+ * 
+ * @since 1.22.4
+ * @version $Id$
+ */
+@Unstable
+public class ConfluenceTocZoneMacroParameters
+{
+    private ConfluenceTocZoneMacroLocationParameter location = ConfluenceTocZoneMacroLocationParameter.BOTH;
+
+    private ConfluenceTocZoneMacroTypeParameter type = ConfluenceTocZoneMacroTypeParameter.LIST;
+
+    private Boolean outline = false;
+
+    private String style = "default";
+
+    private String indent = "";
+
+    private String separator = "brackets";
+
+    private int minLevel = 1;
+
+    private int maxLevel = 7;
+
+    private String include = ".*";
+
+    private String exclude = "\\b\\B";
+
+    private boolean printable = true;
+
+    private String cssClass = "";
+
+    /**
+     * Gets the location parameter.
+     *
+     * @return The location parameter.
+     */
+    public ConfluenceTocZoneMacroLocationParameter getLocation()
+    {
+        return this.location;
+    }
+
+    /**
+     * Sets the location.
+     * 
+     * @param location location parameter.
+     */
+    @PropertyDescription("Defines where the table of contents should appear around the content.")
+    public void setLocation(ConfluenceTocZoneMacroLocationParameter location)
+    {
+        this.location = location;
+    }
+
+    /**
+     * Gets the type parameter.
+     * 
+     * @return The type parameter
+     */
+    public ConfluenceTocZoneMacroTypeParameter getType()
+    {
+        return this.type;
+    }
+
+    /**
+     * Sets the type parameter.
+     * 
+     * @param type type parameter.
+     */
+    @PropertyDescription("Defines the layout of the table of contents.")
+    public void setType(ConfluenceTocZoneMacroTypeParameter type)
+    {
+        this.type = type;
+    }
+
+    /**
+     * Get the outline parameter.
+     * 
+     * @return the outline parameter.
+     */
+    public Boolean isOutline()
+    {
+        return this.outline;
+    }
+
+    /**
+     * Set the outline parameter.
+     * 
+     * @param outline the outline parameter.
+     */
+    @PropertyDescription("Add numbering before the headings in the table of contents.")
+    public void setOutline(Boolean outline)
+    {
+        this.outline = outline;
+    }
+
+    /**
+     * Get the style parameter.
+     * 
+     * @return the style parameter.
+     */
+    public String getStyle()
+    {
+        return this.style;
+    }
+
+    /**
+     * Set the style parameter.
+     * 
+     * @param style the style parameter.
+     */
+    @PropertyDescription("When in List layout, defines the CSS style of the bullets.")
+    public void setStyle(String style)
+    {
+        this.style = style;
+    }
+
+    /**
+     * Get the indent parameter.
+     * 
+     * @return the indent parameter.
+     */
+    public String getIndent()
+    {
+        return this.indent;
+    }
+
+    /**
+     * Set the indent parameter.
+     * 
+     * @param indent the indent parameter.
+     */
+    @PropertyDescription("When in List layout, sets the amount by which to indent the headings."
+        + " Must be a valid CSS size.")
+    public void setIndent(String indent)
+    {
+        this.indent = indent;
+    }
+
+    /**
+     * Get the separator parameter.
+     * 
+     * @return the separator parameter.
+     */
+    public String getSeparator()
+    {
+        return this.separator;
+    }
+
+    /**
+     * Set the separator parameter.
+     * 
+     * @param separator the separator parameter.
+     */
+    @PropertyDescription("When in Flat layout, defines how the headings are separated.")
+    public void setSeparator(String separator)
+    {
+        this.separator = separator;
+    }
+
+    /**
+     * Get the minLevel parameter.
+     * 
+     * @return the minLevel parameter.
+     */
+    public int getMinLevel()
+    {
+        return this.minLevel;
+    }
+
+    /**
+     * Set the minLevel parameter.
+     * 
+     * @param minLevel the minLevel parameter.
+     */
+    @PropertyDescription("Sets the highest level of importance a heading can have to appear in the table of contents.")
+    public void setMinLevel(int minLevel)
+    {
+        this.minLevel = minLevel;
+    }
+
+    /**
+     * Get the maxLevel parameter.
+     * 
+     * @return the maxLevel parameter.
+     */
+    public int getMaxLevel()
+    {
+        return this.maxLevel;
+    }
+
+    /**
+     * Set the maxLevel parameter.
+     * 
+     * @param maxLevel the maxLevel parameter.
+     */
+    @PropertyDescription("Sets the lowest level of importance a heading can have to appear in the table of contents.")
+    public void setMaxLevel(int maxLevel)
+    {
+        this.maxLevel = maxLevel;
+    }
+
+    /**
+     * Get the include parameter.
+     * 
+     * @return the include parameter.
+     */
+    public String getInclude()
+    {
+        return this.include;
+    }
+
+    /**
+     * Set the include parameter.
+     * 
+     * @param include the include parameter.
+     */
+    @PropertyDescription("Sets a regular expression that headings must match to appear in the table of contents.")
+    public void setInclude(String include)
+    {
+        this.include = include;
+    }
+
+    /**
+     * Get the exclude parameter.
+     * 
+     * @return the exclude parameter.
+     */
+    public String getExclude()
+    {
+        return this.exclude;
+    }
+
+    /**
+     * Set the exclude parameter.
+     * 
+     * @param exclude the exclude parameter.
+     */
+    @PropertyDescription("Sets a regular expression that headings shouldn't match to appear in the table of contents.")
+    public void setExclude(String exclude)
+    {
+        this.exclude = exclude;
+    }
+
+    /**
+     * Get the printable parameter.
+     * 
+     * @return the printable parameter.
+     */
+    public boolean isPrintable()
+    {
+        return this.printable;
+    }
+
+    /**
+     * Set the printable parameter.
+     * 
+     * @param printable the printable parameter.
+     */
+    @PropertyDescription("When unset, the table of content will not appear in printed versions of the page.")
+    public void setPrintable(boolean printable)
+    {
+        this.printable = printable;
+    }
+
+    /**
+     * Get the class parameter.
+     * 
+     * @return the class parameter.
+     */
+    public String getCssClass()
+    {
+        return this.cssClass;
+    }
+
+    /**
+     * Set the class parameter.
+     * 
+     * @param cssClass the class parameter.
+     */
+    // class is a property of every Object.
+    @PropertyId("class")
+    @PropertyDescription("When set, a div with the specificied class will wrap the table of contents"
+        + ", allowing for custom styling.")
+    public void setCssClass(String cssClass)
+    {
+        this.cssClass = cssClass;
+    }
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroTypeParameter.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceTocZoneMacroTypeParameter.java
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.xwiki.macros.confluence;
+
+/**
+ * Defines the style for the Table of Contents.
+ * 
+ * @version $Id$
+ * @since 1.22.4
+ */
+public enum ConfluenceTocZoneMacroTypeParameter
+{
+    /**
+     * The Table of Contents is displayed as a vertical list.
+     */
+    LIST,
+    /**
+     * The Table of Contents is displayed in one line.
+     */
+    FLAT
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
@@ -1,2 +1,3 @@
 com.xwiki.macros.confluence.ConfluenceDetailsScriptService
 com.xwiki.macros.confluence.ConfluenceOutgoingLinksMacro
+com.xwiki.macros.confluence.ConfluenceTocZoneMacro


### PR DESCRIPTION
Hi,

Here is an implementation proposal for a confluence toc-zone macro bridge.

## Details
It is based on the following documentation: https://confluence.atlassian.com/doc/table-of-content-zone-macro-189890742.html
As well as from experimenting with the extension on a confluence instance.

All the parameters are implemented.
The bridge behave similarly to the original toc-zone macro.

## Screenshots
See some comparative screenshots to have an overview.

### Default parameters
![Default](https://github.com/user-attachments/assets/abe10cc4-6a0d-4259-afa5-4bf289a72843)
![Default_XWiki](https://github.com/user-attachments/assets/880720bf-60b1-4ff6-9306-e20611ad9802)

### Bottom, Flat and Outline
![BottomFlatOutline](https://github.com/user-attachments/assets/95083cee-f6ef-40b0-a080-213ca12d9c2a)
![BottomFlatOutline_XWiki](https://github.com/user-attachments/assets/628e4234-8618-43c3-a896-5a9accd3c433)

### Include `.*First.*` and levels 2-3.
![2-3FirstRegex](https://github.com/user-attachments/assets/099d444e-6976-4f7d-9172-08944af49c8e)
![2-3FirstRegex_XWiki](https://github.com/user-attachments/assets/862bddc6-28e6-4739-bea9-f3d15b3a0f81)

## Reviewing

This is my first macro implementation.
I believe having a review, even a quick one, could be highly beneficial both for the quality of the result, as well as the quality of my future code.
I want to bring the eventual reviewer(s) attention to escaping.
I tried making something that seemed safe to me, I'd like to have a confirmation that user input is properly handled.

Thank you,

Dorian.
