### PR TITLE
The bulleted list does not work as expected when used in the "Expand"  macro (#323).

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -188,6 +188,11 @@ Hello 👀
   border: none;
 }
 
+.confluence-expand-macro.panel.panel-default .panel-body ul {
+  list-style-type: revert;
+  padding-left: revert;
+}
+
 .confluence-expand-macro.panel {
   background: unset;
 }</code>


### PR DESCRIPTION
* The issue was caused by a CSS rule on the .panel ul that removed the padding and the list-style-type. To fix this, I added a rule that targets the .confluence-expand-macro.panel.panel-default .panel-body ul and reverts the CSS style.