### PR TITLE
 detailssummary doesn't show lists contained in listed pages in the table #362

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
@@ -177,7 +177,7 @@ public class ConfluenceDetailsScriptService implements ScriptService
             String key = printer.toString().trim();
 
             printer.clear();
-            xwikiSyntaxRenderer.render(cells.get(1).getChildren().get(0), printer);
+            xwikiSyntaxRenderer.render(cells.get(1).getChildren(), printer);
 
             String value = printer.toString().trim();
 

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
@@ -86,7 +86,6 @@ public class ConfluenceDetailsScriptService implements ScriptService
     @Named("xwiki/2.1")
     private BlockRenderer xwikiSyntaxRenderer;
 
-
     @Inject
     private Provider<ComponentManager> componentManagerProvider;
 

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
@@ -83,6 +83,11 @@ public class ConfluenceDetailsScriptService implements ScriptService
     private BlockRenderer plainTextRenderer;
 
     @Inject
+    @Named("xwiki/2.1")
+    private BlockRenderer xwikiSyntaxRenderer;
+
+
+    @Inject
     private Provider<ComponentManager> componentManagerProvider;
 
     @Inject
@@ -173,7 +178,8 @@ public class ConfluenceDetailsScriptService implements ScriptService
             String key = printer.toString().trim();
 
             printer.clear();
-            plainTextRenderer.render(cells.get(1), printer);
+            xwikiSyntaxRenderer.render(cells.get(1).getChildren().get(0), printer);
+
             String value = printer.toString().trim();
 
             String keyLower = key.toLowerCase();

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
@@ -309,7 +309,7 @@ Bridges are there for compatibility with content migrated from Confluence and t
         #if ($foreach.first)
           |=$title##
           #foreach ($cell in $row)
-            |=$services.rendering.escape($cell, $xwiki.currentContentSyntaxId)##
+            |=$cell##
           #end##
           #if ($showLastModified)|=$services.localization.render('rendering.macro.detailssummary.lastModified')#end##
           #if ($showCreator)|=$services.localization.render('rendering.macro.detailssummary.creator')#end##
@@ -320,7 +320,7 @@ Bridges are there for compatibility with content migrated from Confluence and t
             #set ($d = $xwiki.getDocument($row.get(0)))
           #end##
           #foreach ($cell in $row)
-            |#if ($foreach.first)[[$cell]]#{else}$services.rendering.escape($cell, $xwiki.currentContentSyntaxId)#end##
+            |#if ($foreach.first)[[$cell]]#{else}$cell#end##
           #end##
           #if ($showLastModified)|$xwiki.formatDate($d.getDate())#end##
           #if ($showCreator)|#if ($d.getCreator() == "XWiki.superadmin")superadmin#else[[$d.getCreator()]]#end#end##

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
@@ -320,7 +320,7 @@ Bridges are there for compatibility with content migrated from Confluence and t
             #set ($d = $xwiki.getDocument($row.get(0)))
           #end##
           #foreach ($cell in $row)
-            |#if ($foreach.first)[[$cell]]#{else}$cell#end##
+            | ((( #if ($foreach.first)[[$cell]]#{else}$cell#end ))) ##
           #end##
           #if ($showLastModified)|$xwiki.formatDate($d.getDate())#end##
           #if ($showCreator)|#if ($d.getCreator() == "XWiki.superadmin")superadmin#else[[$d.getCreator()]]#end#end##


### PR DESCRIPTION
The issue occurs because we are currently using a plain BlockRenderer to display the values of the columns. The plain BlockRenderer removes any macro calls or XWiki syntax. To resolve this, I replaced the BlockRenderer used for the table values with an XWikiSyntax BlockRenderer and updated the front end to avoid escaping the XWiki syntax. I understand this might be seen as a potential security issue, but the macro only displays entries for pages you already have viewing rights for.