### PR TITLE
Show-if/hide-if: Add display parameter

### DIFF
--- a/xwiki-pro-macros-api/checkstyle-suppressions.xml
+++ b/xwiki-pro-macros-api/checkstyle-suppressions.xml
@@ -9,7 +9,7 @@
             files="src/main/java/com/xwiki/macros/excerptinclude/internal/macro/ExcerptIncludeMacro\.java"/>
   <suppress checks="NPathComplexity|CyclomaticComplexity|ReturnCount"
             files="src/main/java/com/xwiki/macros/script/ExpandScriptService\.java"/>
-  <suppress checks="CyclomaticComplexity" files="AbstractShowHideIfMacro.java"/>
+  <suppress checks="CyclomaticComplexity|NPathComplexity|NCSS|ExecutableStatementCount" files="AbstractShowHideIfMacro.java"/>
   <suppress checks="NPathComplexity|CyclomaticComplexity|TodoComment|" files="TabGroupMacro.java"/>
   <suppress checks="NPathComplexity|CyclomaticComplexity|" files="TabMacro.java"/>
 </suppressions>

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/internal/macro/AbstractShowHideIfMacro.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/internal/macro/AbstractShowHideIfMacro.java
@@ -83,7 +83,8 @@ public abstract class AbstractShowHideIfMacro extends AbstractProMacro<ShowHideI
     {
         boolean matchAnyRes = false;
         boolean matchAllRes = true;
-        DocumentReference userReference = xwikiContextProvider.get().getUserReference();
+        XWikiContext xcontext = xwikiContextProvider.get();
+        DocumentReference userReference = xcontext.getUserReference();
         ShowHideIfMacroParameters.AuthType authTypeParam = parameters.getAuthenticationType();
         if (userReference != null) {
             UserReferenceList usersParam = parameters.getUsers();
@@ -124,6 +125,30 @@ public abstract class AbstractShowHideIfMacro extends AbstractProMacro<ShowHideI
                 break;
             default:
                 break;
+        }
+
+        if (parameters.getDisplayType() != null
+            && parameters.getDisplayType() != ShowHideIfMacroParameters.DisplayType.NONE)
+        {
+            boolean isExportPrintable = "export".equalsIgnoreCase(xcontext.getAction());
+            switch (parameters.getDisplayType()) {
+                case DEFAULT:
+                    if (isExportPrintable) {
+                        matchAllRes = false;
+                    } else {
+                        matchAnyRes = true;
+                    }
+                    break;
+                case PRINTABLE:
+                    if (isExportPrintable) {
+                        matchAnyRes = true;
+                    } else {
+                        matchAllRes = false;
+                    }
+                    break;
+                default:
+                    break;
+            }
         }
         return (parameters.getMatchUsing() == ShowHideIfMacroParameters.Matcher.ANY && matchAnyRes)
             || (parameters.getMatchUsing() == ShowHideIfMacroParameters.Matcher.ALL && matchAllRes);

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/macro/ShowHideIfMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/macro/ShowHideIfMacroParameters.java
@@ -41,6 +41,8 @@ public class ShowHideIfMacroParameters
 
     private GroupReferenceList groups;
 
+    private DisplayType displayType;
+
     /**
      * @version $Id: $
      */
@@ -73,6 +75,25 @@ public class ShowHideIfMacroParameters
          * Match only if user is not authenticated.
          */
         ANONYMOUS
+    }
+
+    /**
+     * @version $Id: $
+     */
+    public enum DisplayType
+    {
+        /**
+         * Display in any cases.
+         */
+        NONE,
+        /**
+         * Dislay in general case except in PRINTABLE cases.
+         */
+        DEFAULT,
+        /**
+         * Display in printable case. This include ODT and PDF export and printing.
+         */
+        PRINTABLE,
     }
 
     /**
@@ -146,5 +167,21 @@ public class ShowHideIfMacroParameters
     public void setGroups(GroupReferenceList groups)
     {
         this.groups = groups;
+    }
+
+    /**
+     * @return the display type which should match.
+     */
+    public DisplayType getDisplayType()
+    {
+        return displayType;
+    }
+
+    /**
+     * @param displayType the display type which should match.
+     */
+    public void setDisplayType(DisplayType displayType)
+    {
+        this.displayType = displayType;
     }
 }

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/macro/ShowHideIfMacroParameters.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/showhideif/macro/ShowHideIfMacroParameters.java
@@ -79,6 +79,7 @@ public class ShowHideIfMacroParameters
 
     /**
      * @version $Id: $
+     * @since 1.26.0
      */
     public enum DisplayType
     {
@@ -180,6 +181,10 @@ public class ShowHideIfMacroParameters
     /**
      * @param displayType the display type which should match.
      */
+    @PropertyDescription("The type of display to show this content. I could be:\n"
+        + "* None: don't take into account for this parameter.\n"
+        + "* Default: Show on screen (when the content is not printed).\n"
+        + "* Printable: Show when it's printed. Will be enabled for PDF or ODT export.")
     public void setDisplayType(DisplayType displayType)
     {
         this.displayType = displayType;


### PR DESCRIPTION
Note that the current implementation is in Java, but an other solution would be to do it in CSS as described in this page: https://extensions.xwiki.org/xwiki/bin/view/Extension/PDF%20Export%20Application/#HAdaptthecontentforPDFexport

The java version is quite easier but have 2 inconvenient:
- In the HTML export, it's considered as printable which is not really correct.
- If we print directly from the browser (without using the PDF export tools), it's not considered as printable.

The PDF and ODT export work well.
