### PR TITLE
"FALLBACK" message is displayed over the list of users #409

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Contributors.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Contributors.xml
@@ -441,7 +441,6 @@ Result:
       #end
     #end
   #else
-    FALLBACK
     #set($pages = [$page])
   #end
   #set($contributors = {})


### PR DESCRIPTION
* The fallback appeared to be a leftover, so I removed it.
The commit: https://github.com/xwikisas/xwiki-pro-macros/commit/a41cb4c651660f3889e28fd602116d482ad97f23