### PR TITLE
Use a space picker for the space parameter #405, Add a tag picker for the label field #407

### DIFF
--- a/xwiki-pro-macros-ui/pom.xml
+++ b/xwiki-pro-macros-ui/pom.xml
@@ -92,5 +92,11 @@
       <artifactId>xwiki-pro-macros-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.xwiki.commons</groupId>
+      <artifactId>xwiki-pro-commons-pickers-ui</artifactId>
+      <type>xar</type>
+      <version>1.0.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ContentReportTableMacro.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ContentReportTableMacro.xml
@@ -313,8 +313,9 @@ The result is the following :
       <code>{{velocity output="false"}}
 #macro (executeMacro)
   ## Used parameters :
-  #set($labels = $wikimacro.parameters.get('labels'))
-  #set($spaces = $wikimacro.parameters.get('spaces'))
+  ## TODO When https://jira.xwiki.org/browse/XWIKI-18965 is fixed move back to the newer $wikimacro API
+  #set($labels = $xcontext.macro.params.labels)
+  #set($spaces = $xcontext.macro.params.spaces)
   #set($maxResults = $wikimacro.parameters.get('maxResults'))
   #if("$!maxResults" == '')
     #set($maxResults = 20)
@@ -334,7 +335,7 @@ The result is the following :
   })
   #if("$!spaces" != '')
     #set ($statement = $statement + ' and (')
-    #foreach($space in $spaces.split('(?&lt;!\\\\), '))
+    #foreach($space in $spaces.split('(?&lt;!\\\\), ?'))
       #if($foreach.index &gt; 0)
         #set($statement = $statement + ' or ')
       #end
@@ -478,7 +479,7 @@ The result is the following :
       <name>labels</name>
     </property>
     <property>
-      <type/>
+      <type>com.xwiki.pickers.TagsReference</type>
     </property>
   </object>
   <object>
@@ -557,7 +558,7 @@ The result is the following :
       <name>spaces</name>
     </property>
     <property>
-      <type/>
+      <type>com.xwiki.pickers.SuggestSpacesReference</type>
     </property>
   </object>
   <object>


### PR DESCRIPTION
Updated the macro parameter to use pickers and reverted to the older $xcontext.macro API. This is because, although the new pickers have converters that make them compatible with the $wikimacro API, there is a bug in the platform that requires restarting your instance for the converters to work. https://jira.xwiki.org/browse/XWIKI-18965

Preview:
![image](https://github.com/user-attachments/assets/1edfe46e-7018-44a0-9c65-6c8b63ca831e)
