### PR TITLE
Upload files functionality of the "Confluence bridge for Attachments"macro doesn't work #371 & Delete functionality of the "Confluence bridge for Attachments" macro doesn't work as expected #372

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceAttachments.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceAttachments.xml
@@ -763,8 +763,8 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     'forceSkinAction': true,
     'language': $xcontext.locale
   }))
-  #set ($discard = $xwiki.jsx.use("Confluence.Macros.Attachments"))
-  #set ($discard = $xwiki.ssx.use("Confluence.Macros.Attachments"))
+  #set ($discard = $xwiki.jsx.use("Confluence.Macros.ConfluenceAttachments"))
+  #set ($discard = $xwiki.ssx.use("Confluence.Macros.ConfluenceAttachments"))
   #set ($document = $doc)
   #if ("$!wikimacro.parameters.page" != '')
     #set ($document = $xwiki.getDocument("$!wikimacro.parameters.page"))


### PR DESCRIPTION
The issue was caused by commit 31dcf24, which separated the XWiki macros from the Confluence bridges but forgot to update the JavaScript and CSS requests.