### PR TITLE
Support CSS classes macro-layout-section, single, two_equal, macro-layout-cell in the Confluence style sheet #470

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -156,6 +156,9 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 .macro-section, .macro-layout-section {
   display: flex;
   flex-direction: row;
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {
@@ -189,6 +192,86 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   }
   .macro-layout-cell:nth-child(2) {
     flex-basis: 50%;
+  }
+}
+.macro-layout-section {
+  margin-bottom: 20px;
+}
+
+.macro-section, .macro-layout-section {
+  display: flex;
+  flex-direction: row;
+  word-break: break-all;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
+}
+
+.macro-layout-section.single .macro-layout-cell {
+  flex-basis: 100%;
+}
+.macro-layout-section.two_equal .macro-layout-cell {
+  flex-basis: 50%;
+}
+.macro-layout-section.three_equal .macro-layout-cell {
+  flex-basis: 33.33%;
+}
+
+.macro-layout-section.four_equal .macro-layout-cell {
+  flex-basis: 25%;
+}
+
+.macro-layout-section.five_equal .macro-layout-cell {
+  flex-basis: 20%;
+}
+
+.macro-layout-section.two_right_sidebar {
+  .macro-layout-cell {
+    flex-basis: 33.33%;
+  }
+  .macro-layout-cell:first-child {
+    flex-basis: 66.66%;
+  }
+}
+.macro-layout-section.two_left_sidebar {
+  .macro-layout-cell {
+    flex-basis: 66.66%;
+  }
+  .macro-layout-cell:first-child {
+    flex-basis: 33.33%;
+  }
+}
+
+.macro-layout-section.three_with_sidebars {
+  .macro-layout-cell {
+    flex-basis: 25%;
+  }
+  .macro-layout-cell:nth-child(2) {
+    flex-basis: 50%;
+  }
+}
+
+.macro-layout-section.three_right_sidebars {
+  .macro-layout-cell {
+    flex-basis: 25%;
+  }
+  .macro-layout-cell:nth-child(3) {
+    flex-basis: 50%;
+  }
+}
+
+.macro-layout-section.three_left_sidebars {
+  .macro-layout-cell {
+    flex-basis: 25%;
+  }
+  .macro-layout-cell:nth-child(1) {
+    flex-basis: 50%;
+  }
+}
+
+.macro-layout-section {
+  gap: 32px;
+  h1, h2, h3, h4, h5, h6 {
+    margin: 0;
   }
 }
 


### PR DESCRIPTION
1. Updated the CSS to ensure that words wrap correctly and are displayed in a column instead of extending horizontally and causing a scrollbar
2. Added support for up to 5 columns, matching confluence's current cloud version
3. Added support for 2 left and 2 right sidebars when using a 3-column layout

Previews:
![image](https://github.com/user-attachments/assets/639528b6-9a7b-44f4-804a-05bbd816f463)

![image](https://github.com/user-attachments/assets/4bc87859-2c8c-4a7d-91cf-77c6841b626e)

![image](https://github.com/user-attachments/assets/8ef9abe3-ff08-4c66-a0f9-f3a4017ba4cf)
