### PR TITLE
Layout macro introduces whitespaces after 1.26.5 version

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -158,7 +158,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   flex-direction: row;
   word-break: break-all;
   overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {
@@ -196,14 +195,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 }
 .macro-layout-section {
   margin-bottom: 20px;
-}
-
-.macro-section, .macro-layout-section {
-  display: flex;
-  flex-direction: row;
-  word-break: break-all;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {


### PR DESCRIPTION
The issue was created by the white-space: pre-wrap;, which was committed by mistake.