### PR TITLE
The words of a text are truncated when using the Layout macro with Pro Macros Legacy installed #498

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -156,8 +156,7 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 .macro-section, .macro-layout-section {
   display: flex;
   flex-direction: row;
-  word-break: break-all;
-  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .macro-layout-section.single .macro-layout-cell {

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -158,7 +158,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   flex-direction: row;
   word-break: break-all;
   overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {
@@ -196,14 +195,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 }
 .macro-layout-section {
   margin-bottom: 20px;
-}
-
-.macro-section, .macro-layout-section {
-  display: flex;
-  flex-direction: row;
-  word-break: break-all;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/69223f74-1cde-4bb4-843a-605b3777d688)
