### PR TITLE
Services.confluence doesn't return a valid reference #502

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -158,7 +158,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   flex-direction: row;
   word-break: break-all;
   overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {
@@ -196,14 +195,6 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 }
 .macro-layout-section {
   margin-bottom: 20px;
-}
-
-.macro-section, .macro-layout-section {
-  display: flex;
-  flex-direction: row;
-  word-break: break-all;
-  overflow-wrap: break-word;
-  white-space: pre-wrap;
 }
 
 .macro-layout-section.single .macro-layout-cell {


### PR DESCRIPTION
I updated the getSloppySpace method to work with valid xwiki references, as the javadocs indicated that xwiki references can be used