### PR TITLE
View file macro: Width parameter not taken into consideration in the "full" display #516

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -438,10 +438,13 @@ window.addEventListener("DOMContentLoaded", function () {
 
 .viewFileThumbnailCard, .viewFileFull {
   position: relative;
-  width: 10rem !important;
-  height: fit-content;
-  min-height: 10rem !important;
   margin-bottom: 1rem !important;
+}
+
+.viewFileThumbnailCard {
+  width: 10rem !important;
+  height: fit-content !important;
+  min-height: 10rem !important;
 }
 
 span.viewFileThumbnailCard {


### PR DESCRIPTION
Removed the forced CSS from `viewFileFull` class.