### PR TITLE
Confluence_attachments - filter on file type is not working #521

### DIFF
--- a/xwiki-pro-macros-api/src/main/resources/templates/filteredAttachments.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/filteredAttachments.vm
@@ -1,0 +1,123 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('attachment_macros.vm')
+#template('hierarchy_macros.vm')
+#if ($xcontext.action == 'get')
+  #set ($offset = $numbertool.toNumber($request.offset).intValue())
+  ## The offset sent by the live table starts at 1.
+  #set ($offset = $offset - 1)
+  #if (!$offset || $offset < 0)
+    #set ($offset = 0)
+  #end
+  #set ($limit = $numbertool.toNumber($request.limit).intValue())
+  #if (!$limit)
+    #set ($limit = 15)
+  #end
+  ##
+  ## Apply live table filters.
+  ##
+  #set ($constraints = ['attachment.docId = doc.id', 'doc.id = :docId'])
+  #set ($queryParameters = [{
+    'name': 'docId',
+    'match': 'exact',
+    'value': $doc.getId()
+  }])
+  #maybeApplyStringFilter('mimeType' 'prefix' $constraints $queryParameters)
+  #maybeApplyStringFilter('filename' 'partial' $constraints $queryParameters)
+  #maybeApplyIntegerRangeFilter('filesize' $constraints $queryParameters)
+  #maybeApplyDateRangeFilter('date' $constraints $queryParameters)
+  #maybeApplyStringFilter('author' 'partial' $constraints $queryParameters)
+  #set ($whereClause = '')
+  #if ($constraints.size() > 0)
+    #set ($whereClause = 'where ' + $stringtool.join($constraints, ' and '))
+  #end
+  ##
+  ## Determine the sort field and direction.
+  ##
+  #set ($validSortFields = ['mimeType', 'filename', 'doc.fullName', 'filesize', 'date', 'author'])
+  #set ($sortField = $request.sort)
+  #if (!$validSortFields.contains($sortField))
+    #set ($sortField = 'filename')
+  #end
+  #set ($caseInsensitiveSort = $sortField != 'date' && $sortField != 'filesize')
+  #if (!$sortField.startsWith('doc.'))
+    #set ($sortField = "attachment.$sortField")
+  #end
+  #set ($direction = 'asc')
+  #if ("$!request.dir" == 'desc')
+    #set ($direction = 'desc')
+  #end
+  #if ($caseInsensitiveSort)
+    #set ($orderByClause = "order by lower($sortField) $direction, $sortField $direction")
+  #else
+    #set ($orderByClause = "order by $sortField $direction")
+  #end
+  ##
+  ## Compute the final query.
+  ##
+  #set ($query =  $services.query.hql("$whereClause $orderByClause"))
+  #set ($discard = $query.addFilter('attachment'))
+  #set ($discard = $query.setLimit($limit).setOffset($offset))
+  #foreach ($queryParameter in $queryParameters)
+    #if ($queryParameter.match == 'exact')
+      #set ($discard = $query.bindValue($queryParameter.name, $queryParameter.value))
+    #elseif ($queryParameter.match == 'prefix')
+      #set ($query = $query.bindValue($queryParameter.name).literal($queryParameter.value).anyChars().query())
+    #else
+      ## Partial match.
+      #set ($query = $query.bindValue($queryParameter.name).anyChars().literal($queryParameter.value).anyChars().query())
+    #end
+  #end
+  #set ($attachmentsReferences = $query.execute())
+  #set ($regex = $request.patterns.split(','))
+  #set ($attachmentsReferences = $services.filterAttachments.filterAttachmentResults($attachmentsReferences, $regex))
+  #set ($queryString = $escapetool.url({
+    'form_token': $services.csrf.token,
+    'xredirect': "$doc.getURL()#Attachments"
+  }))
+  #set ($results = {
+    "totalrows": $query.count(),
+    "returnedrows": $mathtool.min($attachmentsReferences.size(), $limit),
+    "offset": $mathtool.add($offset, 1),
+    "reqNo": $numbertool.toNumber($request.reqNo).intValue(),
+    "rows": []
+  })
+  #foreach ($attachmentReference in $attachmentsReferences)
+    #set ($hasAccess = $services.security.authorization.hasAccess('view', $attachmentReference))
+    #set ($row = {
+      'doc_viewable': $hasAccess
+    })
+    #if ($hasAccess)
+      #set ($attachment = $doc.getAttachment($attachmentReference.name))
+      #set ($authorReference = $services.model.resolveDocument($attachment.author))
+      #set ($discard = $row.putAll({
+        'id': $attachment.filename,
+        'filename': "#displayFileNameAndVersion($attachmentReference $attachment)",
+        'mimeType': "#displayAttachmentMimeType($attachment)",
+        'filesize': "#displayAttachmentSize($attachment.longSize)",
+        'date': $xwiki.formatDate($attachment.date),
+        'author': "#displayUserNameWithAvatar($attachment.author)",
+        'actions': "#displayAttachmentActions($attachment)"
+      }))
+    #end
+    #set ($discard = $results.rows.add($row))
+  #end
+  #jsonResponse($results)
+#end

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/pom.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/pom.xml
@@ -54,6 +54,13 @@
       <artifactId>confluence-resolvers</artifactId>
       <version>${confluence.version}</version>
     </dependency>
+    <!-- Testing dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
    <plugins>

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/FilterAttachmentsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/FilterAttachmentsScriptService.java
@@ -1,0 +1,65 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.confluence;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Script service for filtering attachments using regex expressions.
+ *
+ * @version $Id$
+ * @since 1.26.18
+ */
+@Component
+@Singleton
+@Named("filterAttachments")
+@Unstable
+public class FilterAttachmentsScriptService implements ScriptService
+{
+    /**
+     * Filters a list of AttachmentReferences by checking if their names match any of the given regex patterns.
+     *
+     * @param attachments the list of AttachmentReference objects to filter
+     * @param regexes the list of regex patterns to match against attachment names
+     * @return a list of AttachmentReferences whose names match at least one regex
+     */
+    public List<AttachmentReference> filterAttachmentResults(List<AttachmentReference> attachments,
+        List<String> regexes)
+    {
+        if ((regexes != null && regexes.size() == 1 && regexes.get(0).isEmpty()) || regexes.isEmpty()) {
+            return attachments;
+        }
+
+        List<Pattern> patterns = regexes.stream().map(Pattern::compile).collect(Collectors.toList());
+        return attachments.stream().filter(
+                attachment -> patterns.stream().anyMatch(pattern -> pattern.matcher(attachment.getName()).matches()))
+            .collect(Collectors.toList());
+    }
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
@@ -5,3 +5,4 @@ com.xwiki.macros.confluence.ConfluenceSpacesScriptService
 com.xwiki.macros.confluence.ConfluenceScriptService
 com.xwiki.macros.confluence.ConfluenceTocZoneMacro
 com.xwiki.macros.confluence.internal.ConfluenceSpaceUtils
+com.xwiki.macros.confluence.FilterAttachmentsScriptService

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/test/java/com/xwiki/macros/confluence/FillterAttachmentsScriptServiceTest.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/test/java/com/xwiki/macros/confluence/FillterAttachmentsScriptServiceTest.java
@@ -1,0 +1,94 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.confluence;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link FilterAttachmentsScriptService}
+ */
+@ComponentTest
+public class FillterAttachmentsScriptServiceTest
+{
+
+    private AttachmentReference attachmentReference1;
+
+    private AttachmentReference attachmentReference2;
+
+    @InjectMockComponents
+    private FilterAttachmentsScriptService filterAttachmentsScriptService;
+
+    @Mock
+    private DocumentReference documentReference;
+    @BeforeEach
+    void setup()
+    {
+        // Can't mock the getName method because it is final, and I chose to instantiate the objects.
+        this.attachmentReference1 = new AttachmentReference("test.pdf", documentReference);
+        this.attachmentReference2 = new AttachmentReference("test.doc", documentReference);
+    }
+
+    @Test
+    void multipleFilters()
+    {
+        List<AttachmentReference> attachmentReferenceList = List.of(attachmentReference1, attachmentReference2);
+        assertEquals(2,
+            filterAttachmentsScriptService.filterAttachmentResults(attachmentReferenceList, List.of(".*pdf", ".*doc"))
+                .size());
+    }
+
+    @Test
+    void singleFilter()
+    {
+        List<AttachmentReference> attachmentReferenceList = List.of(attachmentReference1, attachmentReference2);
+        assertEquals(1,
+            filterAttachmentsScriptService.filterAttachmentResults(attachmentReferenceList, List.of(".*pdf"))
+                .size());
+    }
+
+    @Test
+    void emptyFilter()
+    {
+        List<AttachmentReference> attachmentReferenceList = List.of(attachmentReference1, attachmentReference2);
+        assertEquals(2,
+            filterAttachmentsScriptService.filterAttachmentResults(attachmentReferenceList, List.of())
+                .size());
+    }
+
+    @Test
+    void emptyStringFilter()
+    {
+        List<AttachmentReference> attachmentReferenceList = List.of(attachmentReference1, attachmentReference2);
+        assertEquals(2,
+            filterAttachmentsScriptService.filterAttachmentResults(attachmentReferenceList, List.of(""))
+                .size());
+    }
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceAttachments.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceAttachments.xml
@@ -705,29 +705,14 @@ require(['jquery', 'xwiki-l10n!xwiki-confluence-attachments-messages'], function
     }
   })
 
-  #if ("$!wikimacro.parameters.patterns" != '')
-    #set ($liveDataConfig.query = {})
-    #set ($liveDataConfig.query.filters = [
-      {
-        "property": "filename",
-        "matchAll": true,
-        "constraints": []
-      }
-    ])
-    #set ($filters = $stringtool.split($wikimacro.parameters.patterns, ','))
-    #foreach ($filter in $filters)
-      #set ($discard = $liveDataConfig.query.filters[0].constraints.add(
-        { "operator": "contains", "value": "$!filter.trim()" }
-      ))
-    #end
-  #end
   #set ($sourceParams = {
     'translationPrefix': 'core.viewers.attachments.livetable.',
     'className': 'XWiki.AllAttachments',
-    "\$doc": "$attachmentsDoc"
+    "\$doc": "$attachmentsDoc",
+    'patterns': "$!wikimacro.parameters.patterns"
   })
   #set ($discard = $sourceParams.put('template', 'xpart.vm'))
-  #set ($discard = $sourceParams.put('vm', 'attachmentsjson.vm'))
+  #set ($discard = $sourceParams.put('vm', 'filteredAttachments.vm'))
   #getLiveDataSort($liveDataSort)
   #if ($invalidSortBy)
     {{warning}}


### PR DESCRIPTION
* Added a new scripting service that filters a list of attachments based on regexes
* Added a new .vm template for the livedata that uses the script service
* Added tests for the new scripting service