### PR TITLE
Translation key is visible for recently updated macro #527

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.de.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.de.xml
@@ -20,10 +20,10 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="">
+<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="de">
   <web>XWiki.Macros</web>
   <name>Translations</name>
-  <language/>
+  <language>de</language>
   <defaultLanguage>en</defaultLanguage>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
@@ -412,41 +412,4 @@ rendering.macro.button.name=Macro bouton
 ### Missing: rendering.macro.viewFile.thumbnail.button.title=View file content
 ### Missing: rendering.macro.viewFile.attachmentrequired=Please provide a file to show in the name parameter.
 </content>
-  <object>
-    <name>XWiki.Macros.Translations</name>
-    <number>0</number>
-    <className>XWiki.TranslationDocumentClass</className>
-    <guid>b90aa0be-32d8-4ee8-a478-52a6703538c8</guid>
-    <class>
-      <name>XWiki.TranslationDocumentClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <scope>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>scope</name>
-        <number>1</number>
-        <prettyName>Scope</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </scope>
-    </class>
-    <property>
-      <scope>WIKI</scope>
-    </property>
-  </object>
 </xwikidoc>


### PR DESCRIPTION
The issue was caused by Weblate and this bug: https://jira.xwiki.org/browse/XINFRA-426