### PR TITLE
Fix avatar size team macro

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Team.xml
@@ -430,6 +430,7 @@
   object-fit: cover;
   margin: 0.1ex;
   box-sizing: content-box;
+  height: revert-layer;
 }
 
 .xwikiteam a:hover .xwikiteam-avatar {
@@ -739,7 +740,7 @@
       #else
         #set($escapedSize = $escapetool.xml($size))
         &lt;img
-          class='xwikiteam-avatar fixedSize-$escapedSize'
+          class='xwikiteam-avatar '
           src='$escapetool.xml($return.url)'
           alt='$escapedDisplayUser'
           title='$escapedDisplayUser'
@@ -898,16 +899,6 @@
     #set ($clean = true)
   #end
   {{html clean="$clean"}}
-  ## Starting with XWiki 13.10.4 and 14.1, img tags have a 'height: auto' style set, see XWIKI-19432: Image not to scale
-  ## on mobile. Since this breaks the macro fixed size feature, a specific size is added.
-  #set ($escapedSize = $escapetool.xml($size))
-  &lt;$elem&gt;
-    &lt;style&gt;
-      .fixedSize-$escapedSize {
-        height: ${escapedSize}px;
-      }
-    &lt;/style&gt;
-  &lt;/$elem&gt;
   &lt;$elem class="xwikiteam #if(!$showUsernames)xwikiteam-usernames-hidden#end"&gt;
     #if ($list.size() &gt; 0)
       &lt;span class="xwikiteam-ul"&gt;

--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.de.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Translations.de.xml
@@ -20,10 +20,10 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="">
+<xwikidoc version="1.5" reference="XWiki.Macros.Translations" locale="de">
   <web>XWiki.Macros</web>
   <name>Translations</name>
-  <language/>
+  <language>de</language>
   <defaultLanguage>en</defaultLanguage>
   <translation>0</translation>
   <creator>xwiki:XWiki.Admin</creator>
@@ -412,41 +412,4 @@ rendering.macro.button.name=Macro bouton
 ### Missing: rendering.macro.viewFile.thumbnail.button.title=View file content
 ### Missing: rendering.macro.viewFile.attachmentrequired=Please provide a file to show in the name parameter.
 </content>
-  <object>
-    <name>XWiki.Macros.Translations</name>
-    <number>0</number>
-    <className>XWiki.TranslationDocumentClass</className>
-    <guid>b90aa0be-32d8-4ee8-a478-52a6703538c8</guid>
-    <class>
-      <name>XWiki.TranslationDocumentClass</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <scope>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>scope</name>
-        <number>1</number>
-        <prettyName>Scope</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>GLOBAL|WIKI|USER|ON_DEMAND</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </scope>
-    </class>
-    <property>
-      <scope>WIKI</scope>
-    </property>
-  </object>
 </xwikidoc>


### PR DESCRIPTION
Updated the code to properly set the size of the avatars. The regression has been present since 1.26.0 and was caused by #414