### PR TITLE
Allow confluence_gliffy macro to display a diagram from another page #326

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/GliffyScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/GliffyScriptService.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.confluence;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.confluence.resolvers.ConfluencePageIdResolver;
+import org.xwiki.contrib.confluence.resolvers.ConfluenceResolverException;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.script.service.ScriptService;
+
+/**
+ * Gliffy bridge script service.
+ *
+ * @version $Id$
+ * @since 1.26.20
+ */
+@Component
+@Named("gliffyscript")
+@Singleton
+public class GliffyScriptService implements ScriptService
+{
+    @Inject
+    private ConfluencePageIdResolver confluencePageIdResolver;
+
+    @Inject
+    private DocumentReferenceResolver<String> resolver;
+
+    /**
+     * @param id confluence if of the page
+     * @return the document reference of the migrate page
+     */
+    public DocumentReference getReferenceFromConfluenceID(String id) throws ConfluenceResolverException
+    {
+        if (StringUtils.isNumeric(id)) {
+            EntityReference entityReference = confluencePageIdResolver.getDocumentById(Integer.valueOf(id));
+            return new DocumentReference(entityReference);
+        }
+        return resolver.resolve(id);
+    }
+}

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/resources/META-INF/components.txt
@@ -6,3 +6,4 @@ com.xwiki.macros.confluence.ConfluenceScriptService
 com.xwiki.macros.confluence.ConfluenceTocZoneMacro
 com.xwiki.macros.confluence.internal.ConfluenceSpaceUtils
 com.xwiki.macros.confluence.FilterAttachmentsScriptService
+com.xwiki.macros.confluence.GliffyScriptService

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
@@ -98,6 +98,12 @@
     #if ("$!originalDoc" != '')
       #set ($doc = $xwiki.getDocument($originalDoc))
     #end
+    ## Used for gliffy macros that include a diagram from another page.
+    #set ($pageID = $xcontext.macro.params.pageid)
+    #if ("$!pageID" != '' &amp;&amp; "$!originalDoc" == '')
+      #set ($doc = $xwiki.getDocument($services.gliffyscript.getReferenceFromConfluenceID($pageID)))
+      #set ($originalDoc = $doc)
+    #end
     ## "Constants"
     #set($previewImageName = "${diagramName}.png")
     #set($previewImage = $doc.getAttachment($previewImageName))


### PR DESCRIPTION

* Updated the code to allow the Gliffy macro to display diagrams from other pages via the pageID parameter.