### PR TITLE
Improve thumbnails for view file macro #541

### DIFF
--- a/xwiki-pro-macros-api/pom.xml
+++ b/xwiki-pro-macros-api/pom.xml
@@ -92,6 +92,11 @@
       <artifactId>query</artifactId>
       <version>${cql.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.jodconverter</groupId>
+      <artifactId>jodconverter-local</artifactId>
+      <version>4.4.2</version>
+    </dependency>
   </dependencies>
   <build>
    <plugins>

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentModificationListener.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentModificationListener.java
@@ -1,0 +1,94 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.viewfile.internal;
+
+import java.io.File;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.environment.Environment;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.event.AbstractAttachmentEvent;
+import com.xpn.xwiki.internal.event.AttachmentDeletedEvent;
+import com.xpn.xwiki.internal.event.AttachmentUpdatedEvent;
+
+/**
+ * Listens to attachments delete and update events and attempt to remove the existing thumbnails if they exist.
+ *
+ * @version $Id$
+ * @since 1.26.20
+ */
+@Component
+@Named(AttachmentModificationListener.HINT)
+@Singleton
+public class AttachmentModificationListener extends AbstractEventListener
+{
+    /**
+     * The hint for the component.
+     */
+    public static final String HINT = "ViewFileMacroAttachmentEventListener";
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Environment environment;
+
+    /**
+     * Creates an event-listener filtering for AttachmentDeletedEvent and AttachmentUpdatedEvent.
+     */
+    public AttachmentModificationListener()
+    {
+        super(HINT, new AttachmentDeletedEvent(), new AttachmentUpdatedEvent());
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        if (event instanceof AttachmentUpdatedEvent || event instanceof AttachmentDeletedEvent) {
+            XWikiDocument document = (XWikiDocument) source;
+            if (document != null) {
+                removeThumbnail(((AbstractAttachmentEvent) event).getName(), document);
+            }
+        }
+    }
+
+    private void removeThumbnail(String attachmentName, XWikiDocument document)
+    {
+        File tempDir = new File(environment.getTemporaryDirectory(),
+            "viewfilemacro/thumbnails/" + document.getDocumentReference().toString());
+
+        File thumbnail = new File(tempDir, attachmentName + ".jpg");
+        if (thumbnail.exists()) {
+            if (thumbnail.delete()) {
+                logger.info("Successfully removed thumbnail at location: [{}]", thumbnail.getPath());
+            } else {
+                logger.warn("Failed to remove thumbnail at location: [{}]", thumbnail.getPath());
+            }
+        }
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
@@ -1,0 +1,258 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.viewfile.internal;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.List;
+
+import javax.imageio.ImageIO;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.apache.poi.hslf.usermodel.HSLFSlide;
+import org.apache.poi.hslf.usermodel.HSLFSlideShow;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.jodconverter.core.document.DefaultDocumentFormatRegistry;
+import org.jodconverter.core.office.OfficeManager;
+import org.jodconverter.local.LocalConverter;
+import org.jodconverter.local.office.ExternalOfficeManager;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.environment.Environment;
+import org.xwiki.model.reference.AttachmentReference;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+import net.coobird.thumbnailator.Thumbnails;
+
+/**
+ * Utility class used to generate a thumbnail image for office and pdf files.
+ *
+ * @version $Id$
+ * @since 1.26.20
+ */
+@Component(roles = ThumbnailGenerator.class)
+@Singleton
+public class ThumbnailGenerator
+{
+    private static final List<String> OFFICE_EXTENSIONS = List.of("odp", "doc", "docx", "odt", "xls", "xlsx", "ods");
+
+    private static final String PPT_EXTENSION = "ppt";
+
+    private static final String PPTX_EXTENSION = "pptx";
+
+    private static final List<String> PRESENTATION_EXTENSIONS = List.of(PPT_EXTENSION, PPTX_EXTENSION);
+
+    private static final String THUMBNAILS_PATH = "viewfilemacro/thumbnails/%s";
+
+    private static final String JPG_EXTENSION = ".jpg";
+
+    private static final String JPG = "jpg";
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Environment environment;
+
+    @Inject
+    private Provider<XWikiContext> wikiContextProvider;
+
+    /**
+     * Checks if a thumbnail already exists for the given attachment reference, and if not, attempts to create a
+     * thumbnail image and returns the byte array for it.
+     *
+     * @param attachmentReference the reference of the file for which a thumbnail is requested.
+     * @return the thumbnail content as a byte array if the image was found or successfully created, or an empty byte
+     *     array if an error occurs or if the file extension is not supported.
+     */
+    public byte[] getThumbnailData(AttachmentReference attachmentReference)
+    {
+        try {
+            File tempDir = new File(environment.getTemporaryDirectory(),
+                String.format(THUMBNAILS_PATH, attachmentReference.getDocumentReference().toString()));
+
+            File thumbnail = new File(tempDir, attachmentReference.getName() + JPG_EXTENSION);
+            if (!thumbnail.exists()) {
+                return generateAndGetThumbnailBytes(attachmentReference);
+            } else {
+                return Files.readAllBytes(thumbnail.toPath());
+            }
+        } catch (Exception e) {
+            logger.error("There was an error while attempting to get the thumbnail byte data. Root cause is: [{}]",
+                ExceptionUtils.getRootCauseMessage(e));
+            return new byte[0];
+        }
+    }
+
+    private byte[] generateAndGetThumbnailBytes(AttachmentReference attachmentReference) throws Exception
+    {
+        String extension = getExtension(attachmentReference.getName());
+        if (OFFICE_EXTENSIONS.contains(extension)) {
+            return getOfficeThumbnailBytes(attachmentReference);
+        } else if (PRESENTATION_EXTENSIONS.contains(extension)) {
+            return getPresentationThumbnailBytes(attachmentReference, extension);
+        } else if (extension.equals("pdf")) {
+            return getPDFThumbnailBytes(attachmentReference);
+        } else {
+            logger.warn("Extension type not supported.");
+            return new byte[0];
+        }
+    }
+
+    private byte[] getPDFThumbnailBytes(AttachmentReference attachmentReference) throws Exception
+    {
+        XWikiContext wikiContext = wikiContextProvider.get();
+        XWiki wiki = wikiContext.getWiki();
+        XWikiDocument document = wiki.getDocument(attachmentReference.getDocumentReference(), wikiContext);
+        InputStream is = document.getAttachment(attachmentReference.getName()).getContentInputStream(wikiContext);
+        return generateThumbnail(new ByteArrayInputStream(is.readAllBytes()), attachmentReference);
+    }
+
+    private byte[] getOfficeThumbnailBytes(AttachmentReference attachmentReference) throws Exception
+    {
+        ByteArrayInputStream bais = getPDFContent(attachmentReference);
+        return generateThumbnail(bais, attachmentReference);
+    }
+
+    private ByteArrayInputStream getPDFContent(AttachmentReference attachmentReference) throws Exception
+    {
+        XWikiContext wikiContext = wikiContextProvider.get();
+        XWiki wiki = wikiContext.getWiki();
+        XWikiDocument document = wiki.getDocument(attachmentReference.getDocumentReference(), wikiContext);
+        try (InputStream is = document.getAttachment(attachmentReference.getName())
+            .getContentInputStream(wikiContext); ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            OfficeManager manager = ExternalOfficeManager.builder().portNumbers(8100).build();
+            manager.start();
+            LocalConverter.make(manager).convert(is).to(baos).as(DefaultDocumentFormatRegistry.PDF).execute();
+            manager.stop();
+            return new ByteArrayInputStream(baos.toByteArray());
+        }
+    }
+
+    private byte[] generateThumbnail(ByteArrayInputStream inputStream, AttachmentReference attachmentReference)
+        throws Exception
+    {
+        // Load the PDF document.
+        PDDocument document = PDDocument.load(inputStream);
+        PDFRenderer pdfRenderer = new PDFRenderer(document);
+        // Select the first page (index starts at 0).
+        BufferedImage bim = pdfRenderer.renderImageWithDPI(0, 150);
+        BufferedImage resized = Thumbnails.of(bim).size(150, 212).asBufferedImage();
+        File tempDir = new File(environment.getTemporaryDirectory(),
+            String.format(THUMBNAILS_PATH, attachmentReference.getDocumentReference().toString()));
+        // Create directories if they don't exist.
+        if (!tempDir.exists()) {
+            tempDir.mkdirs();
+        }
+        File thumbnailFile = new File(tempDir, attachmentReference.getName() + JPG_EXTENSION);
+        ImageIO.write(resized, JPG, thumbnailFile);
+        document.close();
+        return Files.readAllBytes(thumbnailFile.toPath());
+    }
+
+    private byte[] getPresentationThumbnailBytes(AttachmentReference attachmentReference, String extension)
+        throws Exception
+    {
+        XWikiContext wikiContext = wikiContextProvider.get();
+        XWiki wiki = wikiContext.getWiki();
+        XWikiDocument document = wiki.getDocument(attachmentReference.getDocumentReference(), wikiContext);
+
+        try (InputStream is = document.getAttachment(attachmentReference.getName())
+            .getContentInputStream(wikiContext))
+        {
+            switch (extension) {
+                case PPT_EXTENSION:
+                    HSLFSlideShow ppt = new HSLFSlideShow(is);
+                    return getSlideThumbnail(ppt, attachmentReference);
+                case PPTX_EXTENSION:
+                    XMLSlideShow pptx = new XMLSlideShow(is);
+                    return getSlideThumbnail(pptx, attachmentReference);
+                default:
+                    logger.warn("Failed to identify the presentation file extension.");
+                    return new byte[0];
+            }
+        }
+    }
+
+    private byte[] getSlideThumbnail(HSLFSlideShow ppt, AttachmentReference attachmentReference) throws IOException
+    {
+        HSLFSlide slide = ppt.getSlides().get(0);
+        Dimension pageSize = ppt.getPageSize();
+        BufferedImage img = new BufferedImage(pageSize.width, pageSize.height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = img.createGraphics();
+        graphics.setPaint(Color.white);
+        graphics.fill(new Rectangle2D.Float(0, 0, pageSize.width, pageSize.height));
+        slide.draw(graphics);
+
+        return getSlideBytes(attachmentReference, img);
+    }
+
+    private byte[] getSlideThumbnail(XMLSlideShow ppt, AttachmentReference attachmentReference) throws IOException
+    {
+        XSLFSlide slide = ppt.getSlides().get(0);
+        Dimension pageSize = ppt.getPageSize();
+        BufferedImage img = new BufferedImage(pageSize.width, pageSize.height, BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = img.createGraphics();
+        graphics.setPaint(Color.white);
+        graphics.fill(new Rectangle2D.Float(0, 0, pageSize.width, pageSize.height));
+        slide.draw(graphics);
+
+        return getSlideBytes(attachmentReference, img);
+    }
+
+    private byte[] getSlideBytes(AttachmentReference attachmentReference, BufferedImage img) throws IOException
+    {
+        BufferedImage resized = Thumbnails.of(img).size(150, 212).asBufferedImage();
+        File tempDir = new File(environment.getTemporaryDirectory(),
+            String.format(THUMBNAILS_PATH, attachmentReference.getDocumentReference().toString()));
+        if (!tempDir.exists()) {
+            tempDir.mkdirs();
+        }
+
+        File outputFile = new File(tempDir, attachmentReference.getName() + JPG_EXTENSION);
+        ImageIO.write(resized, JPG, outputFile);
+
+        return Files.readAllBytes(outputFile.toPath());
+    }
+
+    private String getExtension(String fileName)
+    {
+        return fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
+    }
+}

--- a/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
@@ -13,3 +13,5 @@ com.xwiki.macros.showhideif.macro.ShowIfMacro
 com.xwiki.macros.tab.internal.TabGroupMacro
 com.xwiki.macros.tab.internal.TabMacro
 com.xwiki.macros.viewfile.internal.macro.ViewFileMacro
+com.xwiki.macros.viewfile.internal.AttachmentModificationListener
+com.xwiki.macros.viewfile.internal.ThumbnailGenerator

--- a/xwiki-pro-macros-api/src/main/resources/templates/viewfile/viewFileTemplate.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/viewfile/viewFileTemplate.vm
@@ -18,6 +18,8 @@
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
 ##!source.syntax=xwiki/2.1
+{{include reference='Collabora.Code.UIMacros' /}}
+
 {{velocity output='false'}}
 #template('attachment_macros.vm')
 
@@ -68,9 +70,22 @@
        download="download"
        #if ($thumbnailStyle == "Button") class="button button-primary" #end
        title="$escapetool.xml($services.localization.render('rendering.macro.viewFile.thumbnail.button.title'))">
-      $thumbnail
+      #if (!$thumbnailBase64.isEmpty())
+        <$elem class="image-container">
+          <img class="macro-thumbnail" src="data:image/jpeg;base64,$thumbnailBase64" alt="Thumbnail" />
+          <$elem class="overlay">
+            <span class="overlay-text">View file</span>
+          </$elem>
+        </$elem>
+      #else
+        $thumbnail
+      #end
       <span class="viewFileName">$escapetool.xml($attachmentRef.getName())</span>
     </a>
+    <span hidden>
+      #tableButtonTemplate()
+      <span hidden data-ooExists="$xwiki.exists('UI.XWikiOnlyOfficeCode')" class='oo-installed-check'></span>
+    </span>
   </$elem>
   {{/html}}
 #end

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/ViewFile.xml
@@ -242,16 +242,116 @@ require(['jquery', 'xwiki-meta', 'xwiki-suggestAttachments'], function($, xm) {
   });
 
   pageObserver.observe(document.body, { childList: true, subtree: true });
-});
 
-window.addEventListener("DOMContentLoaded", function () {
-  "use strict";
-  document.addEventListener("click", async function (e) {
+  const getFileExtension = function(fileName) {
+    return fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase();
+  }
+
+  const collaboraGetExtAcceptedAction = function() {
+    const canDoByExt = {};
+    ['doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'csv', 'rtf', 'txt', 'odt', 'ods', 'odp', 'odg'].forEach(function(x) {
+      canDoByExt[x] = 'edit';
+    });
+    ['pdf', 'fb2'].forEach(function(x) {
+      canDoByExt[x] = 'view';
+    });
+    return canDoByExt;
+  };
+  const collaboraCanDoByExt = collaboraGetExtAcceptedAction();
+
+  const getCollaboraAccessRights = function(fileName) {
+    const fileType = getFileExtension(fileName);
+    let accessRights = collaboraCanDoByExt[fileType];
+    if (!accessRights) {
+      return false;
+    }
+    if (!XWiki.hasEdit) {
+      accessRights = 'view';
+    }
+    return accessRights;
+  };
+
+  const getCollaboraActionURL = function(fileName, accessRights, editURL) {
+    const fileParts = fileName.split('@');
+    const queryString = $.param({
+      'document': fileParts[0],
+      'filename': fileParts[1],
+      'action': accessRights,
+      'xpage': 'plain'
+    });
+    editURL += (editURL.indexOf('?') &lt; 0 ? '?' : '&amp;') + queryString;
+    return editURL;
+  };
+
+  const populateCollaboraButton = function(thisButton, fileName, accessRights) {
+    const title = accessRights == 'edit' ? 'Edit using Collabora' : 'View using Collabora';
+    thisButton.attr('title', title);
+    thisButton.find('img').attr('alt', title);
+    thisButton.attr('href', getCollaboraActionURL(fileName, accessRights, thisButton.data('editUrl')));
+  };
+
+  const decorateWithCollaboraButton = function(viewFile, fileRef, spanContainer) {
+    var collaboraButton = $(viewFile).find('a.collaboraEdit');
+    if (collaboraButton.length != 0) {
+      const accessRights = getCollaboraAccessRights(fileRef);
+      if (accessRights) {
+        populateCollaboraButton(collaboraButton, fileRef, accessRights);
+        const clonedButton = collaboraButton.clone(true, true);
+        clonedButton.addClass('btn btn-default');
+        clonedButton.addClass('viewfile-header-button');
+        $(spanContainer).find('.viewFileModal-downloadLink').after(clonedButton);
+      }
+    }
+  }
+
+  const decorateWithXooButton = function(viewFile, fileRef, spanContainer) {
+    if ($(viewFile).find('span.oo-installed-check').data('ooexists')) {
+      const codeDocument = new XWiki.Document('UI', 'XWikiOnlyOfficeCode');
+      var ooCanDoByExt = { };
+      const editableFormats = ['docx', 'xlsx', 'pptx'];
+      const convertibleFormats = ['odt', 'ods', 'odp', 'xls', 'csv', 'doc', 'ppt', 'pps', 'ppsx', 'rtf', 'txt', 'mht', 'html', 'htm'];
+      editableFormats.forEach(function(x) {
+        ooCanDoByExt[x] = 'edit';
+      });
+      convertibleFormats.forEach(function(x) {
+        ooCanDoByExt[x] = 'convert';
+      });
+      ['pdf', 'djvu', 'fb2', 'epub', 'xps'].forEach(function(x) {
+        ooCanDoByExt[x] = 'view';
+      });
+      var fileType = getFileExtension(fileRef);
+      var whatCanDo = ooCanDoByExt[fileType];
+      if (!whatCanDo) {
+        return;
+      }
+      if (!XWiki.hasEdit) {
+        whatCanDo = 'view';
+      }
+      const fileParts = fileRef.split('@');
+      var queryString = $.param({
+        'elem': 'oOActionButtons',
+        'document': fileParts[0],
+        'filename': fileParts[1],
+        'whatCanDo': whatCanDo,
+        'asLink': true
+      });
+
+      $.post(new XWiki.Document('UI', 'XWikiOnlyOfficeCode').getURL('get', queryString), function(data) {
+        const $button = $(data);
+        $button.addClass('btn btn-default');
+        $button.addClass('viewfile-header-button');
+        $(spanContainer).find('.viewFileModal-downloadLink').after($button);
+      });
+    }
+  };
+
+  $(document).on("click", async function (e) {
     if (("" + document.getElementById("xwikicontent")?.contentEditable) == "true") {
       return;
     }
     const viewFile = e.target?.closest(".viewFileThumbnail");
     if (viewFile &amp;&amp; viewFile.dataset.preview === 'true') {
+      const fileRef = viewFile.dataset.ref;
       const popup = new XWiki.widgets.ModalPopup();
       popup.createDialog();
       popup.setContent("&lt;span class='fa fa-spinner'&gt;&lt;/span&gt;");
@@ -261,14 +361,19 @@ window.addEventListener("DOMContentLoaded", function () {
       popup.dialogBox.style.height = "95vh";
       const a = e.target.closest('a');
       const downloadLink = document.createElement("a");
+      const spanContainer = document.createElement("span");
+      spanContainer.className = 'viewfile-actions-header';
       downloadLink.download = true;
       downloadLink.textContent = a.textContent;
-      downloadLink.className = "fa fa-download button button-primary viewFileModal-downloadLink";
+      downloadLink.className = 'fa fa-download button button-primary viewFileModal-downloadLink viewfile-header-button';
       downloadLink.href = a.href;
-      popup.dialogBox.insertBefore(downloadLink, popup.dialogBox.firstChild)
+      spanContainer.appendChild(downloadLink);
+      decorateWithXooButton(viewFile, fileRef, spanContainer);
+      decorateWithCollaboraButton(viewFile, fileRef, spanContainer);
+      $(popup.dialogBox).prepend(spanContainer);
       popup.showDialog();
       e.preventDefault();
-      const response = await fetch(XWiki.contextPath + "/wiki/" + XWiki.currentWiki + "/get/Confluence/Macros/ViewFileService?action=render&amp;attachment=" + encodeURIComponent(viewFile.dataset.ref));
+      const response = await fetch(XWiki.contextPath + "/wiki/" + XWiki.currentWiki + "/get/Confluence/Macros/ViewFileService?action=render&amp;attachment=" + encodeURIComponent(fileRef));
       popup.setContent(await response.text());
       const gallery = popup.dialogBox.querySelector(".gallery");
       if (gallery) {
@@ -394,7 +499,9 @@ window.addEventListener("DOMContentLoaded", function () {
       <cache>long</cache>
     </property>
     <property>
-      <code>.viewFileModal iframe, .viewFileModal .xdialog-content {
+      <code>#template('colorThemeInit.vm')
+
+.viewFileModal iframe, .viewFileModal .xdialog-content {
     height: calc(95vh - 5em);
 }
 
@@ -479,6 +586,49 @@ span.viewFileThumbnailCard {
 
 .viewFileName {
   overflow-wrap: break-word;
+}
+
+.image-container {
+  position: relative;
+}
+
+.macro-thumbnail {
+  display: block;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  opacity: 0;
+  transition: .7s ease;
+  background-color: $theme.buttonPrimaryBackgroundColor;
+}
+
+.image-container:hover .overlay {
+  opacity: 1;
+}
+
+.overlay-text {
+  color: $theme.buttonPrimaryTextColor;
+  font-size: 20px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  -ms-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  text-align: center;
+}
+
+.viewfile-header-button {
+  margin: 1rem 0.7rem;
+}
+
+.viewfile-actions-header {
+  margin: 1rem;
 }</code>
     </property>
     <property>
@@ -488,7 +638,7 @@ span.viewFileThumbnailCard {
       <name>viewFileCSS</name>
     </property>
     <property>
-      <parse>0</parse>
+      <parse>1</parse>
     </property>
     <property>
       <use>onDemand</use>


### PR DESCRIPTION
Added a new util class to generate and retrieve thumbnail data and a listener that removes a thumbnail when an attachment is deleted or renamed. Added Collabora and  OnlyOffice edit options in viewFile popup.

New thumbnail UI:
![image](https://github.com/user-attachments/assets/32c4df5a-0006-4182-b404-24d390fbc465)

Hover overlay:
![image](https://github.com/user-attachments/assets/c735dee6-1cad-438a-b992-7c8290658c37)

Collabora and OnlyOffice edit buttons:
![image](https://github.com/user-attachments/assets/3a86e1b9-2020-42bb-94e4-76246fa3c00e)
