### PR TITLE
Accessing the attachments from the Recently Updated macro does not work #554

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/RecentlyUpdatedService.xml
@@ -272,7 +272,8 @@ $stringtool.replaceEach($v, $solrSpecialChars, $escapedSolrSpecialChars)##
 ## only for the results we are sure to display
 #macro (fetchResults_resolveProperties $results)
   #foreach ($result in $results)
-    #set ($documentFullname = "${result.wiki}:${result.fullname}")
+    #set ($documentName = $result.name.replaceAll('\.', '\\\.'))
+    #set ($documentFullname = "${result.wiki}:${result.space}.${documentName}")
     #set ($document = $xwiki.getDocument($documentFullname))
     #if ($result.type.equals('page') || $result.type.equals('blogpost'))
       #set ($discard = $result.put('href', $document.getURL()))


### PR DESCRIPTION
This was a regression from https://github.com/xwikisas/xwiki-pro-macros/pull/524/files .
The `fullname` field doesn't exist for attachments and comments, so the url breaks.

* Escaped the page name by hand (I didn't find an api/service to do this)