### PR TITLE
Column macro: Styling improvements #553

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceColumn.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceColumn.xml
@@ -152,7 +152,6 @@ This macro is a bridge for the Confluence Column macro. This macro is used in co
     </property>
     <property>
       <code>.macro-column {
-  display: table-cell;
   padding: 5px;
 }</code>
     </property>
@@ -392,6 +391,8 @@ This macro is a bridge for the Confluence Column macro. This macro is used in co
   #if ("$!xcontext.macro.params.width" != '')
     #set ($escapedWidth = $services.rendering.escape($xcontext.macro.params.width, 'xwiki/2.1'))
     #set ($style = "style='width: $escapedWidth'")
+  #else
+    #set ($style = "style='width:100%'")
   #end
   (% class="macro-column" data-width="$escapedWidth" $style %)(((
     {{wikimacrocontent /}}


### PR DESCRIPTION
Added default width to 100% to column macro and removed `display:table-cell` style from column macro.

Before:
![image](https://github.com/user-attachments/assets/244d5a42-260a-48fb-be67-dac6e0cc23d1)

After:
![image](https://github.com/user-attachments/assets/20495417-4f62-4573-9311-bab2f9517170)

Before:
![image](https://github.com/user-attachments/assets/a1be6db0-cc51-4267-a624-993e851dc5ba)

After:
![image](https://github.com/user-attachments/assets/1476849f-a20d-4340-9b1b-49204be0bd17)
