### PR TITLE
Confluence_gliffy bridge always shows a warning when displaying converted diagrams #567

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/GliffyScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/GliffyScriptService.java
@@ -56,7 +56,7 @@ public class GliffyScriptService implements ScriptService
     public DocumentReference getReferenceFromConfluenceID(String id) throws ConfluenceResolverException
     {
         if (StringUtils.isNumeric(id)) {
-            EntityReference entityReference = confluencePageIdResolver.getDocumentById(Integer.valueOf(id));
+            EntityReference entityReference = confluencePageIdResolver.getDocumentById(Long.valueOf(id));
             if (entityReference == null) {
                 return null;
             }

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
@@ -103,7 +103,13 @@
     ## Used for gliffy macros that include a diagram from another page.
     #set ($pageID = $xcontext.macro.params.pageid)
     #if ("$!pageID" != '' &amp;&amp; "$!originalDoc" == '')
-      #set ($diagramDocument = $xwiki.getDocument($services.gliffyscript.getReferenceFromConfluenceID($pageID)))
+      #set ($reference = $services.gliffyscript.getReferenceFromConfluenceID($pageID))
+      ## When the reference is null we should display a warning.
+      #if ($reference)
+        #set ($diagramDocument = $xwiki.getDocument($reference))
+      #else
+        #set ($displayWarning = true)
+      #end
       #set ($originalDoc = $diagramDocument)
     #end
     ## "Constants"
@@ -173,7 +179,7 @@
             )))
           )))
         #end
-      #else
+      #elseif("$pageID" != "" &amp;&amp; $displayWarning)
         ##If the display fails then show a warning.
         #set ($syntax = $services.rendering.resolveSyntax($xwiki.getCurrentContentSyntaxId()))
         #set ($message = $services.localization.render('confluencediagram.warning.notfound'))


### PR DESCRIPTION
* Updated the code to include a variable that displays the warning only if `gliffy_include` doesn't find a valid reference.
* Updated the ID from an int to a long to prevent overflow issues.
