### PR TITLE
Confluence_detailssummary does not correctly show images from details#569

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
@@ -328,7 +328,11 @@ Bridges are there for compatibility with content migrated from Confluence and t
             #if (!$title)
               #set ($title = $cell)
             #end
-            | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$cell]]#{else}$cell#end ))) ##
+            | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$cell]]#{else}##
+            {{context document="$row.get(0)" restricted="true"}}##
+              $cell##
+            {{/context}}
+            #end )))##
           #end##
           #if ($showLastModified)|$xwiki.formatDate($d.getDate())#end##
           #if ($showCreator)|#if ($d.getCreator() == "XWiki.superadmin")superadmin#else[[$d.getCreator()]]#end#end##


### PR DESCRIPTION
* Updated the code to use the context macro to make sure that the references are resolved correctly when rendering the details macros.

Preview:
![464079587-dc6a40a4-6aea-4b2f-95be-b51313d02a12](https://github.com/user-attachments/assets/6c5b69e2-586c-482a-b0be-25153bc40a36)
