### PR TITLE
Integration tests of macros defined in xwiki pages, that have parameters with custom types, fail to render #583

### DIFF
--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/GenericMacrosIT.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/GenericMacrosIT.java
@@ -89,7 +89,12 @@ public class GenericMacrosIT
 
     private void registerMacros(){
         RegisterMacro register = new RegisterMacro();
+        register.registerMacro(BASE_XWIKI_MACRO_SPACE,"Button");
+        register.registerMacro(BASE_XWIKI_MACRO_SPACE,"MicrosoftStream");
+        register.registerMacro(BASE_XWIKI_MACRO_SPACE,"Panel");
         register.registerMacro(BASE_XWIKI_MACRO_SPACE, "Team");
+        register.registerMacro(BASE_XWIKI_MACRO_SPACE,"Taglist");
+
     }
 
     @BeforeAll

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/generic/RegisterMacro.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/generic/RegisterMacro.java
@@ -24,6 +24,12 @@ import java.util.List;
 
 import org.xwiki.test.ui.po.editor.EditPage;
 
+/**
+ * Helps registering broken rendering macros tht are stored in XWiki pages.
+ *
+ * @version $Id$
+ * @since 1.27.2
+ */
 public class RegisterMacro extends EditPage
 {
     /**


### PR DESCRIPTION
The problem was that the macros were not registered when the app was installed, but resaving the page fixes the issue. For the time being, this is the only solution I could find(Thanks to Marius).