### PR TITLE
View file macro: Gracefully handle big attachments #266

### DIFF
--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentSizeValidator.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentSizeValidator.java
@@ -1,0 +1,171 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.macros.viewfile.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.poi.util.IOUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.AttachmentReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Checks if Office 2007 and ODF document attachments are oversize by checking the ZIP entries size or if an excessive
+ * amount of paragraphs is present. This validator prevents documents from causing performance or memory issues during
+ * processing (e.g., conversion or rendering), by applying constraints derived from Apache POI and LibreOffice
+ * limitations.
+ *
+ * @version $Id$
+ * @since 1.27.1
+ */
+@Component(roles = AttachmentSizeValidator.class)
+@Singleton
+public class AttachmentSizeValidator
+{
+    private static final int MAX_ENTRY_LENGTH = 100_000_000;
+
+    private static final List<String> OLD_OFFICE_EXTENSIONS = List.of("doc", "xls", "ppt");
+
+    private static final int MAX_PARAGRAPHS = 200_000;
+
+    @Inject
+    private Provider<XWikiContext> wikiContextProvider;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Determines whether a given document attachment exceeds safe limits for processing. This method only applies to
+     * Office 2007 and ODF formats attachments.
+     *
+     * @param attachRef The reference to the attachment to check
+     * @return {@code true} if the attachment is oversize, or {@code false} otherwise
+     * @throws XWikiException if an error occurs while attempting to retrieve the attachment and it's content
+     * @throws IOException if an error occurs while reading or parsing the attachment
+     */
+    public boolean isAttachmentOversize(AttachmentReference attachRef) throws XWikiException, IOException
+    {
+        XWikiContext wikiContext = wikiContextProvider.get();
+        XWikiDocument document = wikiContext.getWiki().getDocument(attachRef.getDocumentReference(), wikiContext);
+        XWikiAttachment attachment = document.getAttachment(attachRef.getName());
+        String extension = attachRef.getName().substring(attachRef.getName().lastIndexOf('.') + 1).toLowerCase();
+        boolean isOversize = false;
+        if (!OLD_OFFICE_EXTENSIONS.contains(extension)) {
+            InputStream is = attachment.getContentInputStream(wikiContext);
+            isOversize = containsOversizeEntry(is);
+        }
+        return isOversize;
+    }
+
+    private boolean containsOversizeEntry(InputStream file) throws IOException
+    {
+        int maxEntrySize = IOUtils.getMaxByteArrayInitSize();
+        if (maxEntrySize == -1) {
+            maxEntrySize = MAX_ENTRY_LENGTH;
+        }
+        try (ZipInputStream zis = new ZipInputStream(file)) {
+            ZipEntry entry;
+            while ((entry = zis.getNextEntry()) != null) {
+                // Check the metadata of a DOCX file to verify if the number of paragraphs are above the limit.
+                switch (entry.getName()) {
+                    case "docProps/app.xml":
+                        if (exceedsParagraphLimit(zis, "<Paragraphs>(\\d+)</Paragraphs>", "<Paragraphs>")) {
+                            return true;
+                        }
+                        break;
+                    case "meta.xml":
+                        if (exceedsParagraphLimit(zis, "meta:paragraph-count\\s*=\\s*\"(\\d+)\"", "paragraph-count")) {
+                            return true;
+                        }
+                        break;
+                    default:
+                        // Check if the size of the entry are above the Apache POI max record size.
+                        long entrySize = entry.getSize();
+                        if (entry.getSize() == -1) {
+                            entrySize = getEntrySize(zis);
+                        }
+                        if (entrySize > maxEntrySize) {
+                            logger.warn(
+                                "File entry size is larger then the maximum length for this record type set at [{}].",
+                                maxEntrySize);
+                            return true;
+                        }
+                        break;
+                }
+                zis.closeEntry();
+            }
+        }
+        return false;
+    }
+
+    private boolean exceedsParagraphLimit(ZipInputStream zis, String regex, String selector) throws IOException
+    {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(zis));
+        String line;
+        while ((line = reader.readLine()) != null) {
+            if (line.contains(selector)) {
+                Pattern pattern = Pattern.compile(regex);
+                Matcher matcher = pattern.matcher(line);
+                if (matcher.find()) {
+                    try {
+                        int paragraphCount = Integer.parseInt(matcher.group(1));
+                        if (paragraphCount > MAX_PARAGRAPHS) {
+                            logger.warn("File oversize: too many paragraphs ({}).", paragraphCount);
+                            return true;
+                        }
+                    } catch (NumberFormatException e) {
+                        logger.error("Failed to subtract the number of paragraphs. Root cause is: [{}]",
+                            ExceptionUtils.getRootCauseMessage(e));
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private long getEntrySize(ZipInputStream zis) throws IOException
+    {
+        long size = 0;
+        int read;
+        byte[] buffer = new byte[8192];
+        while ((read = zis.read(buffer)) != -1) {
+            size += read;
+        }
+        return size;
+    }
+}

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentSizeValidator.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentSizeValidator.java
@@ -48,7 +48,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
  * Checks if Office 2007 and ODF document attachments are oversize by checking the ZIP entries size or if an excessive
  * amount of paragraphs is present. This validator prevents documents from causing performance or memory issues during
  * processing (e.g., conversion or rendering), by applying constraints derived from Apache POI and LibreOffice
- * limitations.
+ * limitations. This class can be removed after this issue is fixed:
+ * XWIKI-11174: Do not compromise the XWiki instance when viewing an office document too large to be HTML-cleaned
  *
  * @version $Id$
  * @since 1.27.1

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
@@ -171,8 +171,9 @@ public class ThumbnailGenerator
         try (InputStream is = document.getAttachment(attachmentReference.getName()).getContentInputStream(wikiContext);
              ByteArrayOutputStream baos = new ByteArrayOutputStream())
         {
-            OfficeManager manager =
-                ExternalOfficeManager.builder().portNumbers(officeServerConfig.getServerPorts()).build();
+            // Set an execution timeout equivalent to 10 seconds.
+            OfficeManager manager = ExternalOfficeManager.builder().portNumbers(officeServerConfig.getServerPorts())
+                .taskExecutionTimeout(10000L).build();
             manager.start();
             LocalConverter.make(manager).convert(is).to(baos).as(DefaultDocumentFormatRegistry.PDF).execute();
             manager.stop();

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/ViewFileMacro.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/ViewFileMacro.java
@@ -29,6 +29,7 @@ import javax.script.ScriptContext;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.AttachmentReferenceResolver;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.macro.MacroExecutionException;
@@ -38,6 +39,7 @@ import org.xwiki.template.Template;
 import org.xwiki.template.TemplateManager;
 
 import com.xwiki.macros.AbstractProMacro;
+import com.xwiki.macros.viewfile.internal.AttachmentSizeValidator;
 import com.xwiki.macros.viewfile.internal.ThumbnailGenerator;
 import com.xwiki.macros.viewfile.macro.ViewFileMacroParameters;
 
@@ -65,6 +67,9 @@ public class ViewFileMacro extends AbstractProMacro<ViewFileMacroParameters>
     @Named("current")
     private AttachmentReferenceResolver<String> attachmentReferenceResolver;
 
+    @Inject
+    private AttachmentSizeValidator attachmentSizeValidator;
+
     /**
      * Create and initialize the descriptor of the macro.
      */
@@ -83,20 +88,26 @@ public class ViewFileMacro extends AbstractProMacro<ViewFileMacroParameters>
     protected List<Block> internalExecute(ViewFileMacroParameters parameters, String content,
         MacroTransformationContext context) throws MacroExecutionException
     {
-        byte[] thumbnailBytes =
-            thumbnailGenerator.getThumbnailData(attachmentReferenceResolver.resolve(parameters.getName()));
-        Template customTemplate = this.templateManager.getTemplate("viewfile/viewFileTemplate.vm");
-        ScriptContext scriptContext = scriptContextManager.getScriptContext();
-
-        scriptContext.setAttribute("params", parameters, ScriptContext.ENGINE_SCOPE);
-        scriptContext.setAttribute("isInline", context.isInline(), ScriptContext.ENGINE_SCOPE);
-        String base64 = Base64.getEncoder().encodeToString(thumbnailBytes);
-        scriptContext.setAttribute("thumbnailBase64", base64, ScriptContext.ENGINE_SCOPE);
-        if (context.getTransformationContext().getTargetSyntax() != null) {
-            String targetSyntaxId = context.getTransformationContext().getTargetSyntax().getType().getId();
-            scriptContext.setAttribute("targetSyntaxId", targetSyntaxId, ScriptContext.ENGINE_SCOPE);
-        }
         try {
+            AttachmentReference attachRef = attachmentReferenceResolver.resolve(parameters.getName());
+            boolean isOversize = attachmentSizeValidator.isAttachmentOversize(attachRef);
+            byte[] thumbnailBytes = new byte[0];
+            // Get the thumbnail data only if the display is thumbnail and the attachment is not oversize.
+            if (!isOversize) {
+                thumbnailBytes = thumbnailGenerator.getThumbnailData(attachRef);
+            }
+            Template customTemplate = this.templateManager.getTemplate("viewfile/viewFileTemplate.vm");
+            ScriptContext scriptContext = scriptContextManager.getScriptContext();
+
+            scriptContext.setAttribute("params", parameters, ScriptContext.ENGINE_SCOPE);
+            scriptContext.setAttribute("isInline", context.isInline(), ScriptContext.ENGINE_SCOPE);
+            String base64 = Base64.getEncoder().encodeToString(thumbnailBytes);
+            scriptContext.setAttribute("thumbnailBase64", base64, ScriptContext.ENGINE_SCOPE);
+            scriptContext.setAttribute("isOversize", isOversize, ScriptContext.ENGINE_SCOPE);
+            if (context.getTransformationContext().getTargetSyntax() != null) {
+                String targetSyntaxId = context.getTransformationContext().getTargetSyntax().getType().getId();
+                scriptContext.setAttribute("targetSyntaxId", targetSyntaxId, ScriptContext.ENGINE_SCOPE);
+            }
             return this.templateManager.execute(customTemplate).getChildren();
         } catch (Exception e) {
             throw new MacroExecutionException(ExceptionUtils.getRootCauseMessage(e));

--- a/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-pro-macros-api/src/main/resources/META-INF/components.txt
@@ -14,3 +14,4 @@ com.xwiki.macros.tab.internal.TabMacro
 com.xwiki.macros.viewfile.internal.macro.ViewFileMacro
 com.xwiki.macros.viewfile.internal.AttachmentModificationListener
 com.xwiki.macros.viewfile.internal.ThumbnailGenerator
+com.xwiki.macros.viewfile.internal.AttachmentSizeValidator

--- a/xwiki-pro-macros-api/src/main/resources/templates/viewfile/viewFileTemplate.vm
+++ b/xwiki-pro-macros-api/src/main/resources/templates/viewfile/viewFileTemplate.vm
@@ -53,6 +53,9 @@
     #set ($elem = 'div')
     #set ($clean = true)
   #end
+  #if ($isOversize)
+    #set ($previewSupported = false)
+  #end
   #set ($attachment = $xwiki.getDocument($attachmentRef.getParent()).getAttachment($attachmentRef.getName()))
   #set ($thumbnail = "#displayAttachmentMimeType($attachment)")
   #if ($thumbnail.charAt(0) == '#')
@@ -180,7 +183,7 @@
   #end
   #set ($inEditMode = $xcontext.action == 'edit' || $targetSyntaxId == 'annotatedhtml' ||
     $targetSyntaxId == 'annotatedxhtml' || $request.outputSyntax == 'annotatedhtml')
-  #if (($display == 'FULL' || $display == 'full') && ($isInline || $inEditMode))
+  #if (($display == 'FULL' || $display == 'full') && ($isInline || $inEditMode || $isOversize))
     #set ($display = 'thumbnail')
   #end
   #if ($display == 'FULL' || $display == 'full')


### PR DESCRIPTION
### Root issue:
The root cause of the issue comes from the office macro, I'm assuming, from the converter and the applied image filters: https://github.com/xwiki/xwiki-platform/blob/2baba8175f80b2b915db5b88bba988b24cff89fe/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java#L151-L153
I think an easy fix for this issue would be adding a `taskExecutionTimeout` to the conversion builder. 
The error that I got when the rendering failed:
```
2025-07-18 16:11:04,436 [jodconverter-poolentry-1] ERROR o.j.l.t.LocalConversionTask    - Local conversion failed. 
org.jodconverter.core.office.OfficeException: Could not apply filter org.jodconverter.local.filter.text.LinkedImagesEmbedderFilter.
 at org.jodconverter.local.filter.AbstractFilterChain.doFilter(AbstractFilterChain.java:114)
 at org.jodconverter.local.filter.AbstractFilterChain.doFilter(AbstractFilterChain.java:91)
 at org.jodconverter.local.filter.DefaultFilterChain.doFilter(DefaultFilterChain.java:98)
 at org.jodconverter.local.task.LocalConversionTask.modifyDocument(LocalConversionTask.java:167)
 at org.jodconverter.local.task.LocalConversionTask.execute(LocalConversionTask.java:118)
 at org.jodconverter.local.office.LocalOfficeManagerPoolEntry.doExecute(LocalOfficeManagerPoolEntry.java:120)
 at org.jodconverter.core.office.AbstractOfficeManagerPoolEntry.lambda$execute$0(AbstractOfficeManagerPoolEntry.java:80)
 at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
 at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
 at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
 at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.sun.star.lang.DisposedException: null
 at com.sun.star.lib.uno.environments.remote.JobQueue.removeJob(JobQueue.java:210)
 at com.sun.star.lib.uno.environments.remote.JobQueue.enter(JobQueue.java:330)
 at com.sun.star.lib.uno.environments.remote.JobQueue.enter(JobQueue.java:303)
 at com.sun.star.lib.uno.environments.remote.JavaThreadPool.enter(JavaThreadPool.java:87)
 at com.sun.star.lib.uno.bridges.java_remote.java_remote_bridge.sendRequest(java_remote_bridge.java:636)
 at com.sun.star.lib.uno.bridges.java_remote.ProxyFactory$Handler.request(ProxyFactory.java:146)
 at com.sun.star.lib.uno.bridges.java_remote.ProxyFactory$Handler.invoke(ProxyFactory.java:128)
 at com.sun.proxy.$Proxy178.getGraphicObjects(Unknown Source)
 at org.jodconverter.local.filter.text.LinkedImagesEmbedderFilter.convertLinkedImagesToEmbedded(LinkedImagesEmbedderFilter.java:85)
 at org.jodconverter.local.filter.text.LinkedImagesEmbedderFilter.doFilter(LinkedImagesEmbedderFilter.java:68)
 at org.jodconverter.local.filter.AbstractFilterChain.doFilter(AbstractFilterChain.java:110)
 ... 10 common frames omitted
Caused by: java.io.IOException: com.sun.star.io.IOException: EOF reached - socket,host=127.0.0.1,port=8100,tcpNoDelay=1,localHost=localhost,localPort=51596,peerHost=localhost,peerPort=8100
 at com.sun.star.lib.uno.bridges.java_remote.XConnectionInputStream_Adapter.read(XConnectionInputStream_Adapter.java:55)
 at java.base/java.io.DataInputStream.readInt(DataInputStream.java:392)
 at com.sun.star.lib.uno.protocols.urp.urp.readBlock(urp.java:355)
 at com.sun.star.lib.uno.protocols.urp.urp.readMessage(urp.java:92)
 at com.sun.star.lib.uno.bridges.java_remote.java_remote_bridge$MessageDispatcher.run(java_remote_bridge.java:105)
```
### Applied solutions:

- Added thumbnail conversion timeout.
- Added a new class to validate the size of an attachment with checks:
  - for the number of paragraphs of a DOCX/ODT file .
  - that the zip entry size of a `Microsoft open XML` file or `open document` file formats are above the Apache POI max record size (found it to be 100,000,000).
- Files that are oversize, are forced to thumbnail (no image) and can only be downloaded.

I've found from error logs (both from cloud and local instances) that the Apache POI max record size is 100,000,000:
```
Caused by: org.apache.poi.util.RecordFormatException: Tried to read data but the maximum length for this record type is 100,000,000.
If the file is not corrupt or large, please open an issue on bugzilla to request 
increasing the maximum allowable size for this record type.
```
**This solution only applies to**  `Microsoft open XML` file or `open document` file formats, not to the old `Microsoft Word Binary File format` (.doc, .xls, .ppt files). A solution for those files could be imposing a hard limit based on the worst case scenario. I'm not sure this would be a great solution, as I tested .doc files of over 30mb that contained images and they were successfully rendered, but failed to render a 17mb file that had over 200k paragraphs. This, in my opinion, is a short, partial fix until the root problem is fixed in the platform. 

### Other methods that were tried to fix the issue:

1. Attempted to find a relation:
    - Between the memory available and the file size to try prevent the rendering of an attachment if the memory is too low.
    - Between error occurrence and the file size, to limit the rendering of files above a specific size.
    - Failed: while attempting to find a relation by trial and error, I've noticed that the size of the file or the available memory are not actually the main concern. Zip files (Microsoft 2007 and Open document formats) that were larger then 14mb were successfully rendered, while files smaller then 1mb failed. This was caused due to the fact that the smaller files had massive amount of text and paragraphs, while the larger ones also contained images which were easier to render.
    - I did notice a relationship between large amounts of paragraphs and OOM errors. From testing, I could render files with up to 200k paragraphs, but above 230k it would fail the rendering, no matter the allocated memory (tried to allocate up to 3gb of memory). On the other hand, documents with a lot of characters (tested up to 7m) would not fail to render as long as they are split in paragraphs (one massive paragraph with a few milion characters would easily break the instance). Therefor, I opted for a check for the number of paragraphs.

2. Attempted to create a mock conversion with a set execution timeout
    - Failed: While the idea of a mock conversion of the target file actually succeeded in excluding very large files because the execution timeout was reached, this added a lot of additional processing time to medium files that now took a few seconds to check if they can be converted (with the mock conversion) and then another few seconds to actually be rendered by the office macro.

3. Attempted to accurately read the number of paragraphs in a document by opening it with Apache POI.
    - Failed: To accurately read the number of paragraphs in a document, I'd have to open the document which sometimes breaks the instance (usually when going from inline edit to view mode).
    - Solution: open the `DOCX` or `ODT` as zip files and check the metadata to find the number of paragraphs. While this works, it is however limited by the need that the editor should update the metadata every time the document is edited. Moreover, this cannot be applied to `doc` files, as those are binary files.