### PR TITLE
Confluence_detailssummary doesn't render all the details macros #579

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
@@ -170,7 +170,7 @@ public class ConfluenceDetailsScriptService implements ScriptService
                 continue;
             }
             for (XDOM detailMacro : details) {
-                List<String> row = getRow(List.of(detailMacro), headings, columns, columnsLower, doc.getSyntax());
+                List<String> row = getRow(detailMacro, headings, columns, columnsLower, doc.getSyntax());
                 row.add(0, fullName);
                 rows.add(row);
             }
@@ -237,24 +237,7 @@ public class ConfluenceDetailsScriptService implements ScriptService
         return Collections.emptyList();
     }
 
-    private List<TableRowBlock> findRows(List<XDOM> xdoms, Syntax syntax)
-    {
-        if (xdoms.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        if (xdoms.size() == 1) {
-            return findRows(xdoms.get(0), syntax);
-        }
-
-        List<TableRowBlock> xdomRows = new ArrayList<>();
-        for (XDOM xdom : xdoms) {
-            xdomRows.addAll(findRows(xdom, syntax));
-        }
-        return xdomRows;
-    }
-
-    private List<String> getRow(List<XDOM> xdomDetails, List<String> headings, List<String> columns,
+    private List<String> getRow(XDOM xdomDetails, List<String> headings, List<String> columns,
         List<String> columnsLower, Syntax syntax)
     {
         List<TableRowBlock> xdomRows = findRows(xdomDetails, syntax);

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/ConfluenceDetailsScriptService.java
@@ -169,9 +169,12 @@ public class ConfluenceDetailsScriptService implements ScriptService
             if (CollectionUtils.isEmpty(details)) {
                 continue;
             }
-            List<String> row = getRow(details, headings, columns, columnsLower, doc.getSyntax());
-            row.add(0, fullName);
-            rows.add(row);
+            for (XDOM detailMacro : details) {
+                List<String> row = getRow(List.of(detailMacro), headings, columns, columnsLower, doc.getSyntax());
+                row.add(0, fullName);
+                rows.add(row);
+            }
+
         }
 
         maybeSort(sortBy, reverseSort, columnsLower, rows);

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
@@ -305,38 +305,40 @@ Bridges are there for compatibility with content migrated from Confluence and t
     #if ($details.size() &lt; 2)
       $services.localization.render('rendering.macro.detailssummary.noresults')
     #else
-      #foreach ($row in $details)
-        #if ($foreach.first)
-          |=$title##
-          #foreach ($cell in $row)
-            |=$cell##
-          #end##
-          #if ($showLastModified)|=$services.localization.render('rendering.macro.detailssummary.lastModified')#end##
-          #if ($showCreator)|=$services.localization.render('rendering.macro.detailssummary.creator')#end##
-          #if ($showPageLabels)|=$services.localization.render('rendering.macro.detailssummary.tags')#end##
+      (% class="details_summary" %)
+      (((
+        #foreach ($row in $details)
+          #if ($foreach.first)
+            |=$title##
+            #foreach ($cell in $row)
+              |=$cell##
+            #end##
+            #if ($showLastModified)|=$services.localization.render('rendering.macro.detailssummary.lastModified')#end##
+            #if ($showCreator)|=$services.localization.render('rendering.macro.detailssummary.creator')#end##
+            #if ($showPageLabels)|=$services.localization.render('rendering.macro.detailssummary.tags')#end##
 
-        #else
-          #set ($d = $xwiki.getDocument($row.get(0)))
-          #foreach ($cell in $row)
-            #set ($title = $d.getTitle())
-            #if (!$title)
-              #set ($title = $d.getDocumentReference().getName())
-              #if ($title == "WebHome")
-                #set ($title = $d.getDocumentReference().getParent().getName())
+          #else
+            #set ($d = $xwiki.getDocument($row.get(0)))
+            #foreach ($cell in $row)
+              #set ($title = $d.getTitle())
+              #if (!$title)
+                #set ($title = $d.getDocumentReference().getName())
+                #if ($title == "WebHome")
+                  #set ($title = $d.getDocumentReference().getParent().getName())
+                #end
               #end
-            #end
-            #if (!$title)
-              #set ($title = $cell)
-            #end
-            | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$cell]]#{else}##
-            {{context document="$row.get(0)" restricted="true"}}##
-              $cell##
-            {{/context}}
-            #end )))##
-          #end##
-          #if ($showLastModified)|$xwiki.formatDate($d.getDate())#end##
-          #if ($showCreator)|#if ($d.getCreator() == "XWiki.superadmin")superadmin#else[[$d.getCreator()]]#end#end##
-          #if ($showPageLabels)|#showTags($d)#end##
+              #if (!$title)
+                #set ($title = $cell)
+              #end
+              | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$cell]]#{else}##
+              {{context document="$row.get(0)" restricted="true"}}##
+                $cell##
+              {{/context}}
+              #end )))##
+            #end##
+            #if ($showLastModified)|$xwiki.formatDate($d.getDate())#end##
+            #if ($showCreator)|#if ($d.getCreator() == "XWiki.superadmin")superadmin#else[[$d.getCreator()]]#end#end##
+            #if ($showPageLabels)|#showTags($d)#end##
 
         #end
       #end

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/pom.xml
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/pom.xml
@@ -38,7 +38,7 @@
   <dependencies>
     <dependency>
       <groupId>com.xwiki.pro</groupId>
-      <artifactId>xwiki-pro-macros-ui</artifactId>
+      <artifactId>xwiki-pro-macros-confluence-bridges-ui</artifactId>
       <version>${project.version}</version>
       <type>xar</type>
       <exclusions>
@@ -74,6 +74,11 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-model-api</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-search-solr-query</artifactId>
       <version>${platform.version}</version>
     </dependency>
   </dependencies>

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/AllITs.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/AllITs.java
@@ -37,4 +37,10 @@ class AllITs
     class NestedGenericMacrosIT extends GenericMacrosIT
     {
     }
+
+    @Nested
+    @DisplayName("Tests for the DetailsSummary Macro")
+    class NestedDetailsSummaryIT extends DetailsSummaryIT
+    {
+    }
 }

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/DetailsSummaryIT.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/it/com/xwiki/pro/test/ui/DetailsSummaryIT.java
@@ -1,0 +1,119 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.pro.test.ui;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.tag.test.po.AddTagsPane;
+import org.xwiki.tag.test.po.TaggablePage;
+import org.xwiki.test.docker.junit5.ExtensionOverride;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+import com.xwiki.pro.test.po.confluence.detailssummary.DetailsSummaryMacroViewPage;
+import com.xwiki.pro.test.po.utils.SolrTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * UI tests for the generic detailsSummary macros.
+ *
+ * @version $Id$
+ * @since 1.27.2
+ */
+@UITest(
+    properties = {
+        "xwikiCfgPlugins=com.xpn.xwiki.plugin.tag.TagPlugin",
+    },
+    extensionOverrides = {
+        @ExtensionOverride(
+            extensionId = "com.google.code.findbugs:jsr305",
+            overrides = {
+                "features=com.google.code.findbugs:annotations"
+            }
+        )
+    })
+public class DetailsSummaryIT
+{
+    @BeforeAll
+    void setup(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+    }
+
+    void createPage(TestUtils setup, String tag, String pageName, String content)
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "detailsSummary", pageName);
+        setup.createPage(documentReference, content);
+        if (!tag.isEmpty()) {
+            TaggablePage taggablePage = new TaggablePage();
+            AddTagsPane tagsPane = taggablePage.addTags();
+            tagsPane.setTags(tag);
+            tagsPane.add();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void detailsSummaryWithMultipleDetailsMacros(TestUtils setup) throws Exception
+    {
+        String detailsMacroContent = readTestResourceFile("details/multipleMacrosOnTheSamePage");
+        createPage(setup, "test1", "details_with_multiple_calls", detailsMacroContent);
+        // Wait for the solr indexing
+        SolrTestUtils solrTestUtils = new SolrTestUtils(setup);
+        solrTestUtils.waitEmpyQueue();
+        String detailsSummaryCall =
+            buildMacroCall(Collections.singletonMap("cql", "\"space = " + "currentSpace ( )\""));
+        createPage(setup, "", "detailsSummary", detailsSummaryCall);
+        DetailsSummaryMacroViewPage detailsSummaryMacroViewPage = new DetailsSummaryMacroViewPage();
+        assertEquals(10, detailsSummaryMacroViewPage.entriesCount());
+    }
+
+    private String buildMacroCall(Map<String, String> parameters)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{{confluence_detailssummary ");
+        for (String parameter : parameters.keySet()) {
+            builder.append(String.format("%s=%s", parameter, parameters.get(parameter)));
+        }
+        builder.append(" /}}");
+
+        return builder.toString();
+    }
+
+    private String readTestResourceFile(String fileName)
+    {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(fileName)) {
+            String content = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            return content;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/resources/details/multipleMacrosOnTheSamePage
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-docker/src/test/resources/details/multipleMacrosOnTheSamePage
@@ -1,0 +1,189 @@
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="e92056ac-6d42-4370-aaf7-24011a7f7c5a" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(% style="background-color: #ffffff" %)(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(% style="background-color: #f4f5f7" %)(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-07-01"/}}
+)))
+|=(% style="background-color: #f4f5f7" %)(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="db164333-22ae-4dde-a97e-3a611917a3fb" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-04-29"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="6ac7bc6f-9200-4cee-a2eb-0f4a97565610" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-09-03"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="79a942e8-490a-40e4-b230-605798dba28d" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-08-06"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="48cbf3e2-5e21-4cec-aefa-8c68a15aa05c" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-10-16"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="ccb7a467-93f2-45bd-a061-68871f04a8c3" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2027-07-13"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="495e6325-cf6a-4945-a97c-07a00aa4eece" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2022-07-05"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="07a0c53e-241c-40d4-9b8e-8a6b727f6efe" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-02-03"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="4ed58331-3098-49a1-8823-b8952e4855c7" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2030-07-25"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}
+
+{{confluence_details}}
+(% data-table-width="760" data-layout="default" ac:local-id="f8c6b5a1-40bc-4551-bb31-31d6424e1600" %)
+|=(((
+List ‘keys’ in this column - these will be the column headings in your report table
+)))|(((
+List the ‘value’ for each key in this column - these will populate the rows in your report table
+)))
+|=(((
+**date**
+)))|(((
+{{date format="yyyy-MM-dd" value="2025-07-01"/}}
+)))
+|=(((
+
+)))|(((
+
+)))
+{{/confluence_details}}

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/confluence/detailssummary/DetailsSummaryMacroViewPage.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/confluence/detailssummary/DetailsSummaryMacroViewPage.java
@@ -1,0 +1,74 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.pro.test.po.confluence.detailssummary;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Represents a details summary macro in view mode.
+ *
+ * @version $Id$
+ * @since 1.27.2
+ */
+public class DetailsSummaryMacroViewPage extends ViewPage
+{
+
+    private static final String DETAILS_SUMMARY = ".details_summary";
+
+    private WebElement detailsSummaryMacro;
+
+    /**
+     * Retrieves the details summary macro at the specified index on the page. Throws an error if the macro at the given
+     * index is not found.
+     *
+     * @param index the zero-based index of the details summary macro to retrieve
+     */
+    public DetailsSummaryMacroViewPage(int index)
+    {
+        List<WebElement> detailsSummaryMacros = getDriver().findElements(By.cssSelector(DETAILS_SUMMARY));
+        if (detailsSummaryMacros != null && detailsSummaryMacros.size() < index) {
+            this.detailsSummaryMacro = detailsSummaryMacros.get(index);
+        }
+    }
+
+    /**
+     * Retrieves the first details summary macro on the page. Throws an error if no details summary macro is found.
+     */
+    public DetailsSummaryMacroViewPage()
+    {
+        this.detailsSummaryMacro = getDriver().findElement(By.cssSelector(DETAILS_SUMMARY));
+    }
+
+    /**
+     * @return the number of entries(details blocks) that where found by the macro.
+     */
+    public int entriesCount(){
+        // The table header is also a row so we always should have at least one row.
+        return detailsSummaryMacro.findElements(By.cssSelector("tr")).size() -1;
+    }
+
+
+}
+
+

--- a/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/utils/SolrTestUtils.java
+++ b/xwiki-pro-macros-test/xwiki-pro-macros-test-pageobjects/src/main/java/com/xwiki/pro/test/po/utils/SolrTestUtils.java
@@ -1,0 +1,68 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.pro.test.po.utils;
+
+import org.openqa.selenium.By;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.ui.TestUtils;
+
+/**
+ * Utility class to wait for the Solr indexing.
+ *
+ * @version $Id$
+ * @since 1.27.2
+ */
+public class SolrTestUtils
+{
+    private static final String SOLRSERVICE_SPACE = "TestService";
+
+    private static final String SOLRSERVICE_PAGE = "Solr";
+
+    private static final DocumentReference documentReference =
+        new DocumentReference("xwiki", SOLRSERVICE_SPACE, SOLRSERVICE_PAGE);
+
+    private final TestUtils testUtils;
+
+    public SolrTestUtils(TestUtils testUtils) throws Exception
+    {
+        this.testUtils = testUtils;
+        initService();
+    }
+
+    public void waitEmpyQueue() throws Exception
+    {
+        while (getSolrQueueSize() > 0) {
+            Thread.sleep(100);
+        }
+    }
+
+    private long getSolrQueueSize() throws Exception
+    {
+        testUtils.gotoPage(documentReference);
+        return Integer.parseInt(testUtils.getDriver().findElement(By.id("solr")).getText());
+    }
+
+    private void initService() throws Exception
+    {
+
+        testUtils.createPage(documentReference,
+            "(% id = \"solr\" %)\n" + "(((\n" + "{{velocity}}$services.solr.queueSize{{/velocity}}\n" + ")))");
+    }
+}


### PR DESCRIPTION
Old preview:
<img width="1704" height="501" alt="image" src="https://github.com/user-attachments/assets/c32e0567-db78-49cd-891f-2f564a1c04d9" />
New preview:
<img width="1641" height="814" alt="image" src="https://github.com/user-attachments/assets/f798e950-9a32-4c37-9dc3-1194355cf475" />
