### PR TITLE
Replace deprecated method MathTool.toInteger in Confluence.Macros.Contributors #592

### DIFF
--- a/xwiki-pro-macros-api/src/main/resources/css/userlist.css
+++ b/xwiki-pro-macros-api/src/main/resources/css/userlist.css
@@ -51,7 +51,6 @@
 
   table.xwiki-userlist tr::after {
     clear: both;
-    content: ;
     display: block;
     content: "";
   }

--- a/xwiki-pro-macros-api/src/main/resources/css/userlist.css
+++ b/xwiki-pro-macros-api/src/main/resources/css/userlist.css
@@ -51,6 +51,7 @@
 
   table.xwiki-userlist tr::after {
     clear: both;
+    content: ;
     display: block;
     content: "";
   }

--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Contributors.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Contributors.xml
@@ -463,7 +463,7 @@ Result:
     #set($query = $services.query.xwql("select comment.author, max(comment.date), count(distinct comment) from Document doc, doc.object('XWiki.XWikiComments') comment where doc.fullName in (:d) group by comment.author"))
     #addContributions($query, $pages)
   #end
-  #set($contributions = $xcontext.get('sortContributions').doCall($contributors.values(), $order, $reverse, $mathtool.toInteger($limit)))
+  #set($contributions = $xcontext.get('sortContributions').doCall($contributors.values(), $order, $reverse, $numbertool.toNumber($limit).intValue()))
 
 {{html clean=false}}
     &lt;div class="confluence-contributors"&gt;


### PR DESCRIPTION
Replace deprecated method MathTool.toInteger in Confluence.Macros.Contributors #592