### PR TITLE
Thumbnails fail to be saved on Windows because of invalid file path #619

### DIFF
--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentModificationListener.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/AttachmentModificationListener.java
@@ -20,6 +20,8 @@
 package com.xwiki.macros.viewfile.internal;
 
 import java.io.File;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,7 +29,11 @@ import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
 import org.xwiki.environment.Environment;
+import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.model.reference.AttachmentReferenceResolver;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 
@@ -35,6 +41,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.event.AbstractAttachmentEvent;
 import com.xpn.xwiki.internal.event.AttachmentDeletedEvent;
 import com.xpn.xwiki.internal.event.AttachmentUpdatedEvent;
+
+import static com.xwiki.macros.viewfile.internal.ThumbnailGenerator.THUMBNAILS_PATH;
 
 /**
  * Listens to attachments delete and update events and attempt to remove the existing thumbnails if they exist.
@@ -45,7 +53,7 @@ import com.xpn.xwiki.internal.event.AttachmentUpdatedEvent;
 @Component
 @Named(AttachmentModificationListener.HINT)
 @Singleton
-public class AttachmentModificationListener extends AbstractEventListener
+public class AttachmentModificationListener extends AbstractEventListener implements Initializable
 {
     /**
      * The hint for the component.
@@ -57,6 +65,9 @@ public class AttachmentModificationListener extends AbstractEventListener
 
     @Inject
     private Environment environment;
+
+    @Inject
+    private AttachmentReferenceResolver<String> attachmentResolver;
 
     /**
      * Creates an event-listener filtering for AttachmentDeletedEvent and AttachmentUpdatedEvent.
@@ -77,12 +88,20 @@ public class AttachmentModificationListener extends AbstractEventListener
         }
     }
 
+    @Override
+    public void initialize() throws InitializationException
+    {
+        deleteOldFormat();
+    }
+
     private void removeThumbnail(String attachmentName, XWikiDocument document)
     {
-        File tempDir = new File(environment.getTemporaryDirectory(),
-            "viewfilemacro/thumbnails/" + document.getDocumentReference().toString());
+        File tempDir = new File(environment.getTemporaryDirectory(), THUMBNAILS_PATH);
+        AttachmentReference attachmentReference =
+            attachmentResolver.resolve(attachmentName, document.getDocumentReference());
+        String encodedFileReference = URLEncoder.encode(attachmentReference.toString(), StandardCharsets.UTF_8);
 
-        File thumbnail = new File(tempDir, attachmentName + ".jpg");
+        File thumbnail = new File(tempDir, encodedFileReference + ".jpg");
         if (thumbnail.exists()) {
             if (thumbnail.delete()) {
                 logger.info("Successfully removed thumbnail at location: [{}]", thumbnail.getPath());
@@ -90,5 +109,32 @@ public class AttachmentModificationListener extends AbstractEventListener
                 logger.warn("Failed to remove thumbnail at location: [{}]", thumbnail.getPath());
             }
         }
+    }
+
+    private void deleteOldFormat()
+    {
+        File tempDir = new File(environment.getTemporaryDirectory(), THUMBNAILS_PATH);
+        // Create directories if they don't exist.
+        if (tempDir.exists()) {
+            // Check if the old directory format exists and delete it. To be removed in a few months.
+            for (File oldFolder : tempDir.listFiles()) {
+                if (oldFolder.isDirectory()) {
+                    fileDelete(oldFolder);
+                }
+            }
+        }
+    }
+
+    private static void fileDelete(File oldFolder)
+    {
+        if (oldFolder.isDirectory()) {
+            File[] children = oldFolder.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    fileDelete(child);
+                }
+            }
+        }
+        oldFolder.delete();
     }
 }

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/ThumbnailGenerator.java
@@ -71,6 +71,11 @@ import net.coobird.thumbnailator.Thumbnails;
 @Singleton
 public class ThumbnailGenerator
 {
+    /**
+     * Path to the temporary folder where thumbnails are stored.
+     */
+    public static final String THUMBNAILS_PATH = "viewfilemacro/thumbnails/";
+
     private static final List<String> OFFICE_EXTENSIONS = List.of("odp", "doc", "docx", "odt", "xls", "xlsx", "ods");
 
     private static final String PPT_EXTENSION = "ppt";
@@ -78,8 +83,6 @@ public class ThumbnailGenerator
     private static final String PPTX_EXTENSION = "pptx";
 
     private static final List<String> PRESENTATION_EXTENSIONS = List.of(PPT_EXTENSION, PPTX_EXTENSION);
-
-    private static final String THUMBNAILS_PATH = "viewfilemacro/thumbnails/";
 
     private static final String JPG_EXTENSION = ".jpg";
 
@@ -274,25 +277,7 @@ public class ThumbnailGenerator
         // Create directories if they don't exist.
         if (!tempDir.exists()) {
             tempDir.mkdirs();
-        } else {
-            // Check if the old directory format exists and delete it. To be removed in a few months.
-            for (File oldFolder : tempDir.listFiles()) {
-                if (oldFolder.isDirectory()) {
-                    deleteOldFormat(oldFolder);
-                }
-            }
         }
         return new File(tempDir, encodedFileReference + JPG_EXTENSION);
-    }
-
-    private void deleteOldFormat(File fileOrDir)
-    {
-        File[] children = fileOrDir.listFiles();
-        if (children != null) {
-            for (File child : children) {
-                child.delete();
-            }
-        }
-        fileOrDir.delete();
     }
 }


### PR DESCRIPTION
Adapted the thumbnail generator to use the hash code computed from the document reference and attachment name to identify the thumbnails.