### PR TITLE
confluence_detailssummary does not render the document name correctly when the doc reference contains ~ #577

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceDetailsSummary.xml
@@ -319,6 +319,7 @@ Bridges are there for compatibility with content migrated from Confluence and t
 
           #else
             #set ($d = $xwiki.getDocument($row.get(0)))
+            #set ($escapedReference = $services.rendering.escape($row.get(0), "xwiki/2.1"))
             #foreach ($cell in $row)
               #set ($title = $d.getTitle())
               #if (!$title)
@@ -330,7 +331,7 @@ Bridges are there for compatibility with content migrated from Confluence and t
               #if (!$title)
                 #set ($title = $cell)
               #end
-              | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$cell]]#{else}##
+              | ((( #if ($foreach.first)[[$services.rendering.escape($services.rendering.escape($title, $xwiki.currentContentSyntaxId), $xwiki.currentContentSyntaxId)&gt;&gt;$escapedReference]]#{else}##
               {{context document="$row.get(0)" restricted="true"}}##
                 $cell##
               {{/context}}


### PR DESCRIPTION
Updated the reference to be escaped