### PR TITLE
Improperly closed DIV leads to a huge HTML nesting if you have lots of expand macro calls one after another, slowing down PDF export

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -444,7 +444,7 @@ Hello
           $escapedTitle
         &lt;/span&gt;
       &lt;/span&gt;
-    &lt;div&gt;
+    &lt;/div&gt;
     &lt;div class="panel-body"&gt;
 
       {{wikimacrocontent /}}


### PR DESCRIPTION
Closed div