### PR TITLE
Confluence_layout - layout is not respecting real one when editing in WYSIWYG mode #602

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -158,6 +158,9 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   flex-direction: row;
   word-break: break-word;
 }
+.macro-layout-section > .xwiki-metadata-container.cke_widget_editable {
+  flex-basis: 100%;
+}
 
 .macro-layout-section.single .macro-layout-cell, .macro-layout-section.single .cke_widget_wrapper:has(.macro-layout-cell) {
   flex-basis: 100%;


### PR DESCRIPTION
* Updated css styles for ckeditor
* Deleted duplicated css styles

<img width="1401" height="1335" alt="image" src="https://github.com/user-attachments/assets/228f0742-9c28-4b17-87d6-dfa22d8fdda4" />
