### PR TITLE
TOC entries links don't work with Safari when expand is used and sections are not expanded #647

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/Confluence/Macros/Expand.xml
@@ -145,10 +145,7 @@ Hello
 // and we should follow it so we know when the fix reaches Safari. I also opened
 // https://github.com/xwikisas/xwiki-pro-macros/issues/682 on our side to keep track of the issue and avoid forgetting it.
 require(['jquery'], function ($) {
-	var isSafari = navigator.vendor &amp;&amp; navigator.vendor.indexOf('Apple') &gt; -1 &amp;&amp;
-		navigator.userAgent &amp;&amp;
-		navigator.userAgent.indexOf('CriOS') == -1 &amp;&amp;
-		navigator.userAgent.indexOf('FxiOS') == -1;
+	var isSafari = navigator.vendor &amp;&amp; navigator.vendor.includes('Apple');
 
 	function handleFragment() {
 		let hash = window.location.hash;
@@ -161,7 +158,7 @@ require(['jquery'], function ($) {
 			this.open = true;
 		});
 
-		target[0].scrollIntoView({ behavior: "smooth", block: "start" });
+		target[0].scrollIntoView({ behavior: "auto", block: "start" });
 	}
 	if (isSafari) {
 		console.log("Applying Safari fragment workaround");


### PR DESCRIPTION
The issue is that Apple's Safari doesn't respect the HTML standard and doesn't automatically expand `<details>` elements when a URL fragment targets an element inside them. This issue has been fixed in the WebKit engine that Safari uses, but it hasn't reached Safari yet, so other browsers that use WebKit should work correctly. To fix the issue, I added a small js snippet that checks whether the current browser is Safari, and if it is, we perform the expansion ourselves.