### PR TITLE
Button macro: fall back to font-awesome for unrecognized icons #685

### DIFF
--- a/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
+++ b/xwiki-pro-macros-ui/src/main/resources/XWiki/Macros/Button.xml
@@ -370,7 +370,14 @@ $services.localization.render('rendering.macro.button.description')
         width: $!width;
       "
       class="btn $escapetool.xml($macro.additionalClass)"&gt;
-      $!services.icon.renderHTML($!icon)
+      #if ("$!icon" != "")
+        #set ($iconHTML = "$!services.icon.renderHTML($icon)")
+        #if ($iconHTML == "")
+          &lt;span class="fa fa-$escapetool.xml($icon)"&gt;&lt;/span&gt;
+        #else
+          $iconHTML
+        #end
+      #end
       $label
     &lt;/button&gt;
   &lt;/a&gt;


### PR DESCRIPTION
# Issue URL

https://github.com/xwikisas/xwiki-pro-macros/issues/685

# Changes

## Description

This falls back to font-awesome when no icon is generated for the provided icon name.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
