### PR TITLE
Table not correctly rendered when used into layout macros #767

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -158,6 +158,12 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   flex-direction: row;
   word-break: break-word;
 }
+
+.macro-layout-section table {
+  width: 100%;
+  table-layout: fixed;
+}
+
 .macro-layout-section &gt; .xwiki-metadata-container.cke_widget_editable {
   flex-basis: 100%;
 }


### PR DESCRIPTION
The issue seems to happen because of a weird interaction between flex containers, table-layout: auto, and break-word. Flex shrinks by default the items and because of table-layout: auto, the browser then sizes columns proportionally to their content, so the long column takes most of the width, leaving almost nothing for the shorter one and because break-word allows the splitting at each char the column ends up with a single vertical line.
Preview with the fix:
The example from the issue
<img width="1835" height="1213" alt="image" src="https://github.com/user-attachments/assets/5c81cf51-b4ce-463d-8797-f42370c6e0c3" />

An example with really long single 'words':
<img width="1835" height="1213" alt="image" src="https://github.com/user-attachments/assets/d733910d-77cb-437c-8ac9-d4dc3c416888" />

Some old test for my sanity:

<img width="1896" height="1104" alt="image" src="https://github.com/user-attachments/assets/bdcf7863-1c53-4f85-ada5-e817284ed162" />

<img width="1979" height="1117" alt="image" src="https://github.com/user-attachments/assets/86953baf-664c-42e9-b248-d046f9f13fa1" />

<img width="1830" height="927" alt="image" src="https://github.com/user-attachments/assets/d6a24197-3e8b-4dcc-8e4b-871f79cc829e" />

<img width="1840" height="959" alt="image" src="https://github.com/user-attachments/assets/c4f2ed01-4bea-401f-a8c7-ca8cf2f8bb5d" />
