### PR TITLE
View-file macro ends up with an error in full mode #697

### DIFF
--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/async/AsyncRequest.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/async/AsyncRequest.java
@@ -35,14 +35,18 @@ public class AsyncRequest extends WrappingXWikiRequest
 {
     private final HttpSession session;
 
+    private final String servletPath;
+
     /**
      * @param originalRequest the main thread request.
      * @param session the main thread session.
+     * @param servletPath the main thread servletPath.
      */
-    public AsyncRequest(XWikiRequest originalRequest, HttpSession session)
+    public AsyncRequest(XWikiRequest originalRequest, HttpSession session, String servletPath)
     {
         super(originalRequest);
         this.session = session;
+        this.servletPath = servletPath;
     }
 
     @Override
@@ -55,5 +59,11 @@ public class AsyncRequest extends WrappingXWikiRequest
     public HttpSession getSession(boolean create)
     {
         return this.session;
+    }
+
+    @Override
+    public String getServletPath()
+    {
+        return this.servletPath;
     }
 }

--- a/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/async/ViewFileAsyncFullRenderer.java
+++ b/xwiki-pro-macros-api/src/main/java/com/xwiki/macros/viewfile/internal/macro/async/ViewFileAsyncFullRenderer.java
@@ -129,6 +129,8 @@ public class ViewFileAsyncFullRenderer extends AbstractViewFileAsyncRenderer
 
     private HttpSession session;
 
+    private String servletPath;
+
     private boolean csvFirstLineIsHeader = true;
 
     private String csvDelimiter;
@@ -152,6 +154,7 @@ public class ViewFileAsyncFullRenderer extends AbstractViewFileAsyncRenderer
         XWikiContext wikiContext = this.wikiContextProvider.get();
         this.wikiRequest = wikiContext.getRequest();
         this.session = this.wikiRequest.getSession();
+        this.servletPath = this.wikiRequest.getServletPath();
         this.height = parameters.getOrDefault(HEIGHT_KEY, DEFAULT_HEIGHT);
         this.width = parameters.getOrDefault(WIDTH_KEY, DEFAULT_WIDTH);
         this.fileExtension = parameters.get("fileExtension");
@@ -310,7 +313,7 @@ public class ViewFileAsyncFullRenderer extends AbstractViewFileAsyncRenderer
         // a session/SessionManager as there is no request, so we wrap the original thread request and session to
         // avoid a NullPointerException in DefaultTemporaryAttachmentSessionsManager. To be removed once XWiki parent
         // version is >= 17.4.1.
-        this.wikiContextProvider.get().setRequest(new AsyncRequest(wikiRequest, session));
+        this.wikiContextProvider.get().setRequest(new AsyncRequest(wikiRequest, session, servletPath));
         List<Block> officeMacroResult = displayerMacro.execute(macroParameters, "", transformationContext);
         this.wikiContextProvider.get().setRequest(wikiRequest);
         return wrapWithFullViewFormat(officeMacroResult);


### PR DESCRIPTION
Try a fix: Since the HttpRequest object is recycled by the time it is needed in ViewFileFullAsyncRenderer , add the servletPath (which is the causing the error I think) to the Request wrapper.

```
Caused by: java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade
	at org.apache.catalina.connector.RequestFacade.checkFacade(RequestFacade.java:852)
	at org.apache.catalina.connector.RequestFacade.getServletPath(RequestFacade.java:624)
	at jakarta.servlet.http.HttpServletRequestWrapper.getServletPath(HttpServletRequestWrapper.java:213)
	at jakarta.servlet.http.HttpServletRequestWrapper.getServletPath(HttpServletRequestWrapper.java:213)
	at jakarta.servlet.http.HttpServletRequestWrapper.getServletPath(HttpServletRequestWrapper.java:213)
	at org.xwiki.jakartabridge.servlet.internal.JavaxToJakartaHttpServletRequestWrapper.getServletPath(JavaxToJakartaHttpServletRequestWrapper.java:429)
	at javax.servlet.http.HttpServletRequestWrapper.getServletPath(HttpServletRequestWrapper.java:261)
	at javax.servlet.http.HttpServletRequestWrapper.getServletPath(HttpServletRequestWrapper.java:261)
	at com.xpn.xwiki.XWiki.getServletPath(XWiki.java:5416)
	at com.xpn.xwiki.web.XWikiServletURLFactory.addServletPath(XWikiServletURLFactory.java:351)
	at com.xpn.xwiki.web.XWikiServletURLFactory.internalCreateAttachmentURL(XWikiServletURLFactory.java:749)
	at com.xpn.xwiki.web.XWikiServletURLFactory.createAttachmentURL(XWikiServletURLFactory.java:726)
	at com.xpn.xwiki.XWiki.getAttachmentURL(XWiki.java:5609)
```