### PR TITLE
#774: detailssummary displays "No results" instead of displaying an error message when some CQL feature is unsupported

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/detailssummary/internal/macro/DetailsSummaryMacro.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/detailssummary/internal/macro/DetailsSummaryMacro.java
@@ -124,27 +124,30 @@ public class DetailsSummaryMacro extends AbstractProMacro<DetailsSummaryMacroPar
         List<String> headings = confluenceSummaryProcessor.parseHeadings(parameters.getHeadings());
         // We create the columns here and give the object as a parameter so we can collect the column names as we go in
         // case the user didn't provide them already.
-        List<Block> columns = new ArrayList<>();
         // The first column will always be the document name, but it may be translated to a different name.
         String titleColumnName = parameters.getFirstcolumn().isEmpty()
-                                 ? localizationManager.getTranslationPlain("rendering.macro.detailssummary.firstcolumn")
-                                 : parameters.getFirstcolumn();
-        columns.add(0, new TableHeadCellBlock(parsePlainText(titleColumnName)));
-        if (!headings.isEmpty()) {
-            for (String heading : headings) {
-                Block cell = new TableHeadCellBlock(parsePlainText(heading));
-                columns.add(cell);
-            }
-        }
-        List<String> columnsLower = new ArrayList<>();
-        // Always add the name of the column that holds the document name.
-        columnsLower.add(titleColumnName.toLowerCase());
-        if (!headings.isEmpty()) {
-            for (String heading : headings) {
-                columnsLower.add(heading.toLowerCase());
-            }
+                ? localizationManager.getTranslationPlain("rendering.macro.detailssummary.firstcolumn")
+                : parameters.getFirstcolumn();
+        List<Block> columns = getColumns(titleColumnName, headings);
+        List<String> columnsLower = getColumnsLower(titleColumnName, headings);
+        List<Block> tableRows = getRows(parameters, context, documents, headings, columns, columnsLower);
+
+        enhanceHeader(parameters, columns, columnsLower);
+        // Before adding the header row sort the rows.
+        confluenceSummaryProcessor.maybeSort(parameters.getSort(), parameters.getReverse(), columnsLower, tableRows);
+        tableRows.add(0, new TableRowBlock(columns));
+        // If the table rows has only one row then it means that there were no details macro found, and we should add
+        // a message to make this clear to the user.
+        if (tableRows.size() == 1) {
+            rowsNotFound(tableRows);
         }
 
+        return List.of(new TableBlock(tableRows));
+    }
+
+    private List<Block> getRows(DetailsSummaryMacroParameters parameters, MacroTransformationContext context,
+             List<SolrDocument> documents, List<String> headings, List<Block> columns, List<String> columnsLower)
+    {
         List<Block> tableRows = new ArrayList<>();
         List<RowContext> rawRows = new ArrayList<>();
         for (SolrDocument document : documents) {
@@ -168,18 +171,33 @@ public class DetailsSummaryMacro extends AbstractProMacro<DetailsSummaryMacroPar
                 logger.warn("Failed to render the row with the permissions of the author.", e);
             }
         });
+        return tableRows;
+    }
 
-        enhanceHeader(parameters, columns, columnsLower);
-        // Before adding the header row sort the rows.
-        confluenceSummaryProcessor.maybeSort(parameters.getSort(), parameters.getReverse(), columnsLower, tableRows);
-        tableRows.add(0, new TableRowBlock(columns));
-        // If the table rows has only one row then it means that there were no details macro found, and we should add
-        // a message to make this clear to the user.
-        if (tableRows.size() == 1) {
-            rowsNotFound(tableRows);
+    private List<Block> getColumns(String titleColumnName, List<String> headings)
+    {
+        List<Block> columns = new ArrayList<>();
+        columns.add(0, new TableHeadCellBlock(parsePlainText(titleColumnName)));
+        if (!headings.isEmpty()) {
+            for (String heading : headings) {
+                Block cell = new TableHeadCellBlock(parsePlainText(heading));
+                columns.add(cell);
+            }
         }
+        return columns;
+    }
 
-        return List.of(new TableBlock(tableRows));
+    private static List<String> getColumnsLower(String titleColumnName, List<String> headings)
+    {
+        List<String> columnsLower = new ArrayList<>();
+        // Always add the name of the column that holds the document name.
+        columnsLower.add(titleColumnName.toLowerCase());
+        if (!headings.isEmpty()) {
+            for (String heading : headings) {
+                columnsLower.add(heading.toLowerCase());
+            }
+        }
+        return columnsLower;
     }
 
     protected Map<String, Object> buildQueryMap(DetailsSummaryMacroParameters parameters)

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/detailssummary/internal/macro/DetailsSummaryMacro.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/detailssummary/internal/macro/DetailsSummaryMacro.java
@@ -36,11 +36,14 @@ import javax.inject.Singleton;
 import org.apache.solr.common.SolrDocument;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.cql.aqlparser.exceptions.ParserException;
 import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.query.QueryException;
 import org.xwiki.rendering.async.internal.block.BlockAsyncRendererConfiguration;
 import org.xwiki.rendering.async.internal.block.BlockAsyncRendererExecutor;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.LinkBlock;
+import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.SpaceBlock;
 import org.xwiki.rendering.block.TableBlock;
@@ -120,7 +123,18 @@ public class DetailsSummaryMacro extends AbstractProMacro<DetailsSummaryMacroPar
         MacroTransformationContext context)
     {
 
-        List<SolrDocument> documents = cqlUtils.buildAndExecute(buildQueryMap(parameters));
+        List<SolrDocument> documents;
+        try {
+            documents = cqlUtils.buildAndExecute(buildQueryMap(parameters));
+        } catch (QueryException e) {
+            String message = e.getMessage();
+            if (e.getCause() instanceof ParserException) {
+                // The CQL parser has nice and useful error messages
+                message += "\n" + e.getCause().getMessage();
+            }
+            return List.of(new MacroBlock(
+                "error", Map.of(), message, context.isInline()));
+        }
         List<String> headings = confluenceSummaryProcessor.parseHeadings(parameters.getHeadings());
         // We create the columns here and give the object as a parameter so we can collect the column names as we go in
         // case the user didn't provide them already.

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/internal/cql/CQLUtils.java
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-api/src/main/java/com/xwiki/macros/confluence/internal/cql/CQLUtils.java
@@ -107,9 +107,8 @@ public class CQLUtils
      * @param macroParameters parameters of the macro.
      * @return list of SolrDocuments matching the CQL.
      */
-    public List<SolrDocument> buildAndExecute(Map<String, Object> macroParameters)
+    public List<SolrDocument> buildAndExecute(Map<String, Object> macroParameters) throws QueryException
     {
-
         String cql = (String) macroParameters.getOrDefault(CQL, "");
         String fq = "";
         // If the CQL is not already present as a parameter we try to build it.
@@ -129,24 +128,20 @@ public class CQLUtils
         List<SolrDocument> docs = new ArrayList<>();
         Set<String> alreadyFound = new HashSet<>();
         // Everything is prepared, and we attempt to execute the query.
-        try {
-            Query query = queryManager.createQuery(cql, CQL);
-            if (StringUtils.isNotBlank(fq)) {
-                query.bindValue("fq", fq.trim());
+        Query query = queryManager.createQuery(cql, CQL);
+        if (StringUtils.isNotBlank(fq)) {
+            query.bindValue("fq", fq.trim());
+        }
+        query.setLimit(limit);
+        query.bindValue(SORT, String.format("%s %s", sortField, sortDirection));
+        QueryResponse queryResponse = (QueryResponse) query.execute().get(0);
+        SolrDocumentList documents = queryResponse.getResults();
+        for (SolrDocument document : documents) {
+            String fullRef = String.format("%s:%s", document.get("wiki"), document.get("fullname"));
+            if (!alreadyFound.contains(fullRef)) {
+                docs.add(document);
+                alreadyFound.add(fullRef);
             }
-            query.setLimit(limit);
-            query.bindValue(SORT, String.format("%s %s", sortField, sortDirection));
-            QueryResponse queryResponse = (QueryResponse) query.execute().get(0);
-            SolrDocumentList documents = queryResponse.getResults();
-            for (SolrDocument document : documents) {
-                String fullRef = String.format("%s:%s", document.get("wiki"), document.get("fullname"));
-                if (!alreadyFound.contains(fullRef)) {
-                    docs.add(document);
-                    alreadyFound.add(fullRef);
-                }
-            }
-        } catch (QueryException e) {
-            logger.error("Failed to execute the CQL", e);
         }
 
         return docs;


### PR DESCRIPTION
#774 

In the first commit, I moved some code around to avoid a npath complexity checkstyle error.

- [x] don't squash