### PR TITLE
#789: Titles from layout section macros have less space than standard titles

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -233,8 +233,7 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
 .macro-layout-section {
   gap: 32px;
   h1, h2, h3, h4, h5, h6 {
-    margin: 0;
-    margin-bottom: 10px;
+    margin-top: 0;
   }
 }
 </code>

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/ConfluenceLayoutSection.xml
@@ -234,13 +234,7 @@ This is a bridge for the Confluence Layout Section macro. It is usually used wit
   gap: 32px;
   h1, h2, h3, h4, h5, h6 {
     margin: 0;
-  }
-}
-
-.macro-layout-section {
-  gap: 32px;
-  h1, h2, h3, h4, h5, h6 {
-    margin: 0;
+    margin-bottom: 10px;
   }
 }
 </code>


### PR DESCRIPTION
Fix #789  and also cleanup the duplicate CSS rule.