### PR TITLE
#800: Make the Confluence diagram bridges convert to the new inline diagram macro

### DIFF
--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramMacros.xml
@@ -37,7 +37,14 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#macro(displayConfluenceDiagramModal $id $diagram)
+## Display a button allowing the user to go back to confluence diagram mode
+#macro(displayConfluenceDiagramDeletionModal $id $diagramPage $convertedDiagramFilename)
+  #set($id = $mathtool.random(1, 100000))
+  {{translation key='confluencediagram.delete'/}}
+
+  {{html clean="false"}}
+    &lt;a class="btn btn-primary" data-toggle="modal" data-target="#confluencediagram-${id}-modal"&gt;$escapetool.xml($services.localization.render('confluencediagram.delete.link'))&lt;/a&gt;
+  {{/html}}
 
   {{html clean="false"}}
     &lt;div class="modal fade" id="confluencediagram-${id}-modal" tabindex="-1" role="dialog" aria-labelledby="confluencediagram-${id}-title" aria-hidden="true"&gt;
@@ -55,8 +62,11 @@
           &lt;div class="modal-footer"&gt;
             &lt;button type="button" class="btn btn-secondary" data-dismiss="modal"&gt;$escapetool.xml($services.localization.render('confluencediagram.modal.btn.close'))&lt;/button&gt;
             &lt;form action="" method="post"&gt;
-              &lt;input name="action" value="createDiagram" type="hidden" /&gt;
-              &lt;input name="diagram" class="delete-diagram-page" type="hidden" value="$escapetool.xml($diagram)"/&gt;
+              #if ($diagramPage)
+                &lt;input name="diagramPage" type="hidden" value="$escapetool.xml($diagramPage)"/&gt;
+              #else
+                &lt;input name="convertedDiagramFilename" type="hidden" value="$escapetool.xml($convertedDiagramFilename)"/&gt;
+              #end
               &lt;input type="hidden" name="form_token" value="$escapetool.xml($services.csrf.token)" /&gt;
               &lt;button type="submit" class="btn btn-primary delete-diagram-btn"&gt;$escapetool.xml($services.localization.render("confluencediagram.modal.btn.confirm"))&lt;/button&gt;
             &lt;/form&gt;
@@ -94,6 +104,14 @@
       ## Parameter for the drawio macro
       #set($diagramName = $xcontext.macro.params.diagramName)
     #end
+    #if ($diagramName.endsWith(".drawio"))
+      ## if we fix https://github.com/xwikisas/application-diagram/issues/453,
+      ## a diagram with the .drawio extension can be considered already converted.
+      #set ($convertedDiagramFilenameWithoutExtension = $diagramName.substring(0, $diagramName.length - 7))
+    #else
+      #set ($convertedDiagramFilenameWithoutExtension = $diagramName)
+    #end
+    #set ($convertedDiagramFilename = $convertedDiagramFilenameWithoutExtension + ".diagram.xml")
     ## By default the diagramDocument should be the current doc
     #set ($diagramDocument = $doc)
     ## Get original document
@@ -123,37 +141,33 @@
     #end
     ## Variables
     #set($displayDiagram = true)
-    #set($diagram = $NULL)
+    #set($diagramPage = $NULL)
     ##
     ## Check if the diagram page exists
     #set($diagramDocumentReferenceSerialized = $services.model.serialize($diagramDocument.documentReference, 'local'))
-    #set($diagrams = $services.query.xwql('from doc.object(Confluence.Macros.DiagramClass) as diagramObj where diagramObj.page = :page and diagramObj.diagramName = :diagramName').bindValue('page', $diagramDocumentReferenceSerialized).bindValue('diagramName', "$!diagramName").setLimit(1).execute())
-    #if($diagrams.size() &gt; 0)
-      #set($diagram = $diagrams.get(0))
+    #set($diagramPages = $services.query.xwql('from doc.object(Confluence.Macros.DiagramClass) as diagramObj where diagramObj.page = :page and diagramObj.diagramName = :diagramName').bindValue('page', $diagramDocumentReferenceSerialized).bindValue('diagramName', "$!diagramName").setLimit(1).execute())
+    #if($diagramPages.size() &gt; 0)
+      #set($diagramPage = $diagramPages.get(0))
     #end
     ##
     (% class="confluence-diagram-container" %)(((
       ## The diagram exists -&gt; display it
-      #if($displayDiagram &amp;&amp; $diagram)
-        {{diagram reference="$services.rendering.escape($diagram, $xwiki.currentContentSyntaxId)" cached="false" /}}
+      #if ($diagramPage)
+        {{diagram reference="$services.rendering.escape($diagramPage, $xwiki.currentContentSyntaxId)" cached="false" /}}
 
-        #if($diagram &amp;&amp; $xcontext.action != 'export')
-          ##
-          ## Display a button allowing the user to go back to confluence diagram mode
-          #if ($services.security.authorization.hasAccess('delete', $diagram))
-            #set($id = $mathtool.random(1, 100000))
-            {{translation key='confluencediagram.delete'/}}
-
-            {{html clean="false"}}
-              &lt;a class="btn btn-primary" data-toggle="modal" data-target="#confluencediagram-${id}-modal"&gt;$escapetool.xml($services.localization.render('confluencediagram.delete.link'))&lt;/a&gt;
-            {{/html}}
-
-            #displayConfluenceDiagramModal($id $diagram)
-          #end
+        #if($xcontext.action != 'export' &amp;&amp; $services.security.authorization.hasAccess('delete', $diagramPage))
+          #displayConfluenceDiagramDeletionModal($id $diagramPage $NULL)
         #end
-      #elseif ($displayDiagram &amp;&amp; "$!xcontext.macro.params.diagramUrl" != '')
+      #elseif ("$!xcontext.macro.params.diagramUrl" != '')
         ## Use the externalDiagramUrl parameter from the diagram macro instead.
         {{diagram externalDiagramUrl="$services.rendering.escape($!xcontext.macro.params.diagramUrl, $xwiki.currentContentSyntaxId)"/}}
+      #elseif ($doc.getAttachment($convertedDiagramFilename))
+        ## Display the converted inline diagram
+        {{inlineDiagram diagramName="$services.rendering.escape($convertedDiagramFilenameWithoutExtension, $xwiki.currentContentSyntaxId)" /}}
+
+        #if($xcontext.action != 'export' &amp;&amp; $services.security.authorization.hasAccess('edit', $doc))
+          #displayConfluenceDiagramDeletionModal($id $NULL $convertedDiagramFilename)
+        #end
       #else
         #set($displayDiagram = false)
       #end
@@ -174,7 +188,6 @@
               {{html clean=false}}
                 &lt;form action="" method="post"&gt;
                   &lt;input name="action" value="createDiagram" type="hidden" /&gt;
-                  &lt;input name="pageReferenceSerialized" class="create-diagram-page" value="$escapetool.xml($diagramDocumentReferenceSerialized)" type="hidden" /&gt;
                   &lt;input name="diagramName" class="create-diagram-name" value="$escapetool.xml($diagramName)" type="hidden" /&gt;
                   &lt;input name="diagramPNGName" class="create-diagram-png-name" value="$escapetool.xml($previewImageName)" type="hidden" /&gt;
                   &lt;input type="hidden" name="form_token" value="$escapetool.xml($services.csrf.token)" /&gt;
@@ -298,20 +311,19 @@
       deleteFailureMessage = $jsontool.serialize($services.localization.render('confluencediagram.delete.error'));
 
   var handleCreateDiagram = function () {
-    $('.create-diagram-btn').on('click', function(e){
+    $('.create-diagram-btn').on('click', function (e) {
       e.preventDefault();
 
-      var pageReferenceSerialized = $(this).prevAll('.create-diagram-page').val(),
-          diagramName = $(this).prevAll('.create-diagram-name').val();
+      const diagramName = $(this).prevAll('.create-diagram-name').val();
       const diagramPNGName = $(this).prevAll('.create-diagram-png-name').val();
-      $.ajax({
+      $.post({
         url: serviceURL,
         data: {
           'action' : 'create',
           'form_token': $(this).prevAll('[name="form_token"]').val(),
-          'page' : pageReferenceSerialized,
-          'diagramName' : diagramName,
-          'diagramPNGName' : diagramPNGName
+          docContainingDiagram: document.documentElement.dataset.xwikiReference,
+          diagramName,
+          diagramPNGName
         },
         success: function(data, status) {
           new XWiki.widgets.Notification(createSuccessMessage, 'done');
@@ -328,13 +340,19 @@
     $('.delete-diagram-btn').on('click', function(e){
       e.preventDefault();
 
-      var pageReferenceSerialized = $(this).prevAll('.delete-diagram-page').val();
-      $.ajax({
+      // Only defined if the diagram was converted to an attachment)
+      const convertedDiagramFilename = $(this).prevAll('[name="convertedDiagramFilename"]').val();
+      // If the diagram was converted to a dedicated document, diagramPage is
+      // that document. Otherwise, it is undefined
+      const diagramPage = $(this).prevAll('[name="diagramPage"]').val();
+      $.post({
         url: serviceURL,
         data: {
           'action' : 'delete',
           'form_token': $(this).prevAll('[name="form_token"]').val(),
-          'page' : pageReferenceSerialized
+          convertedDiagramFilename,
+          diagramPage,
+          docContainingDiagram: document.documentElement.dataset.xwikiReference
         },
         success: function(data, status) {
           new XWiki.widgets.Notification(deleteSuccessMessage, 'done');

--- a/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramService.xml
+++ b/xwiki-pro-macros-confluence-bridges/xwiki-pro-macros-confluence-bridges-ui/src/main/resources/Confluence/Macros/DiagramService.xml
@@ -36,40 +36,30 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity output="false"}}
-#macro(getUniquePageReference $space $return)
-  #set($id = $mathtool.random(1, 1000000000))
-  #set($uniquePageName = 'Diagram' + $id)
-  #if($xwiki.getDocument($services.model.resolveDocument("${space}.${uniquePageName}")).isNew())
-    #set($return = $NULL)
-    #setVariable("$return" "${space}.${uniquePageName}")
-  #else
-    #getUniquePageReference($space $return)
-  #end
-#end
-{{/velocity}}
-
-{{velocity}}
+  <content>{{velocity}}
 #if (!$services.csrf.isTokenValid($!request.form_token))
   Invalid CSRF Token.
   $response.setStatus(400)
   #stop
 #end
-#set($createDiagram = "$!request.action" == 'create')
-#set($deleteDiagram = "$!request.action" == 'delete')
-#set($page = $request.page)
-#set($diagramName = $request.diagramName)
-#if($createDiagram &amp;&amp; "$!page" != '' &amp;&amp; "$!diagramName" != '')
-  #set($pageReference = $services.model.resolveDocument($page))
-  #if($services.security.authorization.hasAccess('edit', $pageReference))
-    #set($pageDoc = $xwiki.getDocument($page))
-    #set($diagramAttach = $pageDoc.getAttachment($diagramName))
-    #set($diagramPreviewAttach = $pageDoc.getAttachment("${diagramName}.png"))
+#if ("$!request.action" == 'create' &amp;&amp; $request.diagramName &amp;&amp; $request.docContainingDiagram)
+  #set ($diagramName = $request.diagramName)
+  #if ($diagramName.endsWith(".drawio"))
+    ## this branch should be removed if we fix https://github.com/xwikisas/application-diagram/issues/453
+    #set ($convertedDiagramFilenameWithoutExtension = $diagramName.substring(0, $diagramName.length - 7))
+  #else
+    #set ($convertedDiagramFilenameWithoutExtension = $diagramName)
+  #end
+  #set ($convertedDiagramFilename = $convertedDiagramFilenameWithoutExtension + ".diagram.xml")
+  #set ($docContainingDiagramReference = $services.model.resolveDocument($request.docContainingDiagram))
+  #if ($services.security.authorization.hasAccess('edit', $docContainingDiagramReference))
+    #set ($pageDoc = $xwiki.getDocument($docContainingDiagramReference))
+    #set ($diagramAttach = $pageDoc.getAttachment($diagramName))
+    #set ($diagramPreviewAttach = $pageDoc.getAttachment("${diagramName}.png"))
     #if (!$diagramPreviewAttach)
       #set($diagramPreviewAttach = $pageDoc.getAttachment($request.diagramPNGName))
     #end
     #if($diagramAttach)
-      #getUniquePageReference($xwiki.getDocument($page).space $uniquePageReference)
       #set($diagramContent = $diagramAttach.getContentAsString())
       #if(($diagramContent.contains('&lt;mxfile ') || $diagramContent.contains('&lt;mxfile&gt;')) &amp;&amp; ($diagramContent.contains('&lt;diagram ') || $diagramContent.contains('&lt;diagram&gt;')))
         ## Drawio
@@ -78,16 +68,15 @@
         #set($xml = $services.diagram.importDiagram($diagramContent, $diagramName))
       #end
       #if ("$!xml" != '')
-        #set($diagramDoc = $xwiki.getDocument($uniquePageReference))
-        #set($discard = $diagramDoc.addObject($diagramDoc.newObject('Diagram.DiagramClass')))
-        #set($discard = $diagramDoc.setContent($xml))
-        #set($discard = $diagramDoc.setTitle('Diagram'))
-        #set($diagramObj = $diagramDoc.newObject('Confluence.Macros.DiagramClass'))
-        #set($discard = $diagramObj.set('page', $page))
-        #set($discard = $diagramObj.set('diagramName', $diagramName))
-        #set($discard = $diagramDoc.addObject($diagramObj))
-        #set($diagramPreviewPNG = $diagramDoc.addAttachment('diagram.png', $diagramPreviewAttach.getContent()))
-        #set($discard = $diagramDoc.save($services.localization.render('confluencediagram.create.message')))
+        #if ($pageDoc.getAttachment($convertedDiagramFilename))
+          ## Bad Request
+          #set($logger = $services.logging.getLogger('com.xwiki.macros.diagram.DiagramService'))
+          #set($discard = $logger.warn("could not convert diagram from [{}]; target attachment [{}] already exists", $convertedDiagramFilename))
+          $response.setStatus(400)
+        #else
+          #set($discard = $pageDoc.addAttachment($convertedDiagramFilename, $xml.getBytes()))
+          #set($discard = $pageDoc.save($services.localization.render('confluencediagram.create.message')))
+        #end
       #else
         ## Bad Request
         #set($logger = $services.logging.getLogger('com.xwiki.macros.diagram.DiagramService'))
@@ -102,11 +91,25 @@
     ## Unauthorized
     $response.setStatus(401)
   #end
-#elseif($deleteDiagram &amp;&amp; "$!page" != '')
-  #set($pageReference = $services.model.resolveDocument($page))
-  #if($services.security.authorization.hasAccess('delete', $pageReference))
-    ## Delete
-    $xwiki.getDocument($pageReference).delete()
+#elseif("$!request.action" == 'delete')
+  #if ($request.convertedDiagramFilename)
+    #set ($docContainingDiagram = $request.docContainingDiagram)
+    #set ($docContainingDiagramReference = $services.model.resolveDocument($docContainingDiagram))
+    #if ($services.security.authorization.hasAccess('edit', $docContainingDiagramReference))
+      #set ($pageDoc = $xwiki.getDocument($docContainingDiagramReference))
+      $pageDoc.removeAttachment($request.convertedDiagramFilename)
+      $pageDoc.save("Revert diagram conversion by deleting $request.convertedDiagramFilename")
+    #else
+      ## Unauthorized
+      $response.setStatus(401)
+    #end
+  #elseif($request.diagramPage)
+    #set ($diagramPageReference = $services.model.resolveDocument($request.diagramPage))
+    #if($services.security.authorization.hasAccess('delete', $diagramPageReference))
+      ## Delete
+      #set($diagramPageDoc = $xwiki.getDocument($diagramPageReference))
+      $diagramPageDoc.delete()
+    #end
   #else
     ## Unauthorized
     $response.setStatus(401)


### PR DESCRIPTION
#800 

I made sure and checked that diagrams previously converted with the former means keep working and can be reverted. 